### PR TITLE
docs: fix CLAUDE.md testing commands (PHPUnit, not Pest)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,11 +25,15 @@ npm run dev                         # Vite HMR dev server
 ```
 
 ### Testing
+
+Tests are PHPUnit (`phpunit/phpunit ^13`, run via Artisan) — **not Pest**. Test classes extend `Tests\TestCase`; there is no `Pest.php`. Don't use `./vendor/bin/pest`.
+
 ```bash
-./vendor/bin/pest                   # Run all tests
-./vendor/bin/pest tests/Unit        # Run unit tests only
-./vendor/bin/pest tests/Feature     # Run feature tests only
-./vendor/bin/pest --filter=DoubleEntry  # Run a specific test
+php artisan test                    # Run all tests
+php artisan test tests/Unit         # Run unit tests only
+php artisan test tests/Feature      # Run feature tests only
+php artisan test --filter=DoubleEntry   # Run a specific test/class
+vendor/bin/phpunit tests/Unit/Foo.php   # Single file directly
 php artisan test --coverage         # With coverage report
 ```
 


### PR DESCRIPTION
## What

Corrects the Testing section of `src/CLAUDE.md`: it documented `./vendor/bin/pest` commands, but this project does not use Pest.

## Why

Verified against the codebase:
- `composer.json` requires `phpunit/phpunit ^13` — no `pestphp/pest` dependency
- No `tests/Pest.php`, no Pest `test()`/`it()` syntax anywhere
- All 30 test classes extend `Tests\\TestCase` (PHPUnit style)

The root `CLAUDE.md` already described the suite correctly as PHPUnit via Artisan; this aligns `src/CLAUDE.md` with reality.

## Change

Swapped `./vendor/bin/pest ...` for `php artisan test ...` / `vendor/bin/phpunit` equivalents and added a note that the suite is PHPUnit, not Pest.

Rest of both CLAUDE.md files was verified accurate (panels, services, webhooks, rate limits, Horizon gating, Reverb port, Socialstream 9 providers, Dockerfile/Octane, k8s, conventions).