### PR TITLE
fix(security): IDOR, mass-assignment, XSS hardening + email verification

### DIFF
--- a/app/Http/Controllers/Api/TransactionController.php
+++ b/app/Http/Controllers/Api/TransactionController.php
@@ -16,12 +16,14 @@ class TransactionController extends Controller
     public function index(): AnonymousResourceCollection
     {
         return TransactionResource::collection(
-            Transaction::paginate(15)
+            Transaction::where('user_id', auth()->id())->paginate(15)
         );
     }
 
     public function show(Transaction $transaction): TransactionResource
     {
+        abort_unless($transaction->user_id === auth()->id(), 403);
+
         return new TransactionResource($transaction);
     }
 
@@ -34,6 +36,8 @@ class TransactionController extends Controller
             'description' => 'required|string',
         ]);
 
+        $validated['user_id'] = auth()->id();
+
         $transaction = Transaction::create($validated);
 
         return new TransactionResource($transaction);
@@ -41,6 +45,8 @@ class TransactionController extends Controller
 
     public function update(Request $request, Transaction $transaction): TransactionResource
     {
+        abort_unless($transaction->user_id === auth()->id(), 403);
+
         $validated = $request->validate([
             'account_id' => 'sometimes|exists:accounts,id',
             'amount' => 'sometimes|numeric',
@@ -55,6 +61,8 @@ class TransactionController extends Controller
 
     public function destroy(Transaction $transaction): Response
     {
+        abort_unless($transaction->user_id === auth()->id(), 403);
+
         $transaction->delete();
 
         return response()->noContent();

--- a/app/Http/Controllers/TeamInvitationController.php
+++ b/app/Http/Controllers/TeamInvitationController.php
@@ -22,6 +22,7 @@ class TeamInvitationController extends Controller
 
         $user = User::firstOrCreate(['email' => $request->email], ['password' => bcrypt(Str::random(10))]);
         $team = Team::findOrFail($request->team_id);
+        abort_unless($team->hasUser(auth()->user()), 403);
 
         $invitationToken = Str::random(32);
         $user->invitations()->create([

--- a/app/Models/Account.php
+++ b/app/Models/Account.php
@@ -16,7 +16,6 @@ class Account extends Model
 
     #[\Override]
     protected $fillable = [
-        'user_id',
         'account_number',
         'account_name',
         'account_type',
@@ -44,8 +43,12 @@ class Account extends Model
     {
         parent::boot();
 
-        // Set normal_balance based on account_type if not provided
         static::creating(function ($account): void {
+            if (empty($account->user_id) && auth()->check()) {
+                $account->user_id = auth()->id();
+            }
+
+            // Set normal_balance based on account_type if not provided
             if (! $account->normal_balance) {
                 $account->normal_balance = in_array($account->account_type, ['asset', 'expense'])
                     ? 'debit'

--- a/app/Models/BankConnection.php
+++ b/app/Models/BankConnection.php
@@ -15,19 +15,12 @@ class BankConnection extends Model
 
     #[\Override]
     protected $fillable = [
-        'user_id',
         'bank_id',
         'institution_name',
-        'credentials',
-        'plaid_access_token',
         'plaid_item_id',
         'plaid_institution_id',
         'plaid_cursor',
-        'revolut_access_token',
-        'revolut_refresh_token',
         'revolut_token_expires_at',
-        'wise_access_token',
-        'wise_refresh_token',
         'wise_token_expires_at',
         'status',
         'last_synced_at',
@@ -45,6 +38,15 @@ class BankConnection extends Model
         'wise_token_expires_at' => 'datetime',
         'last_synced_at' => 'datetime',
     ];
+
+    protected static function booted(): void
+    {
+        static::creating(function ($bankConnection): void {
+            if (empty($bankConnection->user_id) && auth()->check()) {
+                $bankConnection->user_id = auth()->id();
+            }
+        });
+    }
 
     public function user()
     {

--- a/app/Models/ConnectedAccount.php
+++ b/app/Models/ConnectedAccount.php
@@ -14,16 +14,12 @@ class ConnectedAccount extends Model
 
     #[\Override]
     protected $fillable = [
-        'user_id',
         'provider',
         'provider_id',
         'name',
         'nickname',
         'email',
         'avatar_path',
-        'token',
-        'secret',
-        'refresh_token',
         'expires_at',
     ];
 
@@ -32,4 +28,13 @@ class ConnectedAccount extends Model
         'created_at' => 'datetime',
         'expires_at' => 'datetime',
     ];
+
+    protected static function booted(): void
+    {
+        static::creating(function ($connectedAccount): void {
+            if (empty($connectedAccount->user_id) && auth()->check()) {
+                $connectedAccount->user_id = auth()->id();
+            }
+        });
+    }
 }

--- a/app/Models/Customer.php
+++ b/app/Models/Customer.php
@@ -25,10 +25,7 @@ class Customer extends Authenticatable
         'customer_email',
         'customer_phone',
         'customer_city',
-        'credit_limit',
-        'current_balance',
         'credit_hold',
-        'password',
     ];
 
     #[\Override]

--- a/app/Models/JournalEntry.php
+++ b/app/Models/JournalEntry.php
@@ -15,17 +15,11 @@ class JournalEntry extends Model
 
     #[\Override]
     protected $fillable = [
-        'user_id',
         'entry_number',
         'entry_date',
         'reference_number',
         'memo',
         'entry_type',
-        'is_approved',
-        'approved_by',
-        'approved_at',
-        'is_posted',
-        'posted_at',
     ];
 
     #[\Override]
@@ -43,6 +37,10 @@ class JournalEntry extends Model
         parent::boot();
 
         static::creating(function ($journalEntry): void {
+            if (empty($journalEntry->user_id) && auth()->check()) {
+                $journalEntry->user_id = auth()->id();
+            }
+
             if (! $journalEntry->entry_number) {
                 $journalEntry->entry_number = static::generateEntryNumber();
             }

--- a/app/Models/TeamInvitation.php
+++ b/app/Models/TeamInvitation.php
@@ -21,7 +21,6 @@ class TeamInvitation extends JetstreamTeamInvitation
     #[\Override]
     protected $fillable = [
         'email',
-        'role',
     ];
 
     /**

--- a/app/Models/Transaction.php
+++ b/app/Models/Transaction.php
@@ -31,10 +31,7 @@ class Transaction extends Model
         'debit_account_id',
         'credit_account_id',
         'bank_statement_id',
-        'reconciled',
         'discrepancy_notes',
-        'reconciled_at',
-        'reconciled_by_user_id',
         'exchange_rate',
         'transaction_type',
         'type',
@@ -42,7 +39,6 @@ class Transaction extends Model
         'bank_connection_id',
         'category',
         'status',
-        'user_id',
     ];
 
     #[\Override]
@@ -59,6 +55,10 @@ class Transaction extends Model
         parent::boot();
 
         static::creating(function ($transaction): void {
+            if (empty($transaction->user_id) && auth()->check()) {
+                $transaction->user_id = auth()->id();
+            }
+
             if (! $transaction->exchange_rate) {
                 $defaultCurrency = Currency::where('is_default', true)->first();
                 if ($defaultCurrency && $transaction->currency_id && $transaction->currency_id !== $defaultCurrency->currency_id) {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -103,19 +103,17 @@ class User extends Authenticatable implements FilamentUser, HasDefaultTenant, Ha
 
     public function canAccessTenant(Model $tenant): bool
     {
-        return true; // $this->ownedTeams->contains($tenant);
+        return $this->ownedTeams->contains($tenant);
     }
 
     public function canAccessPanel(Panel $panel): bool
     {
-        //        return $this->hasVerifiedEmail();
-        return true;
+        return $this->hasVerifiedEmail();
     }
 
     public function canAccessFilament(): bool
     {
-        //        return $this->hasVerifiedEmail();
-        return true;
+        return $this->hasVerifiedEmail();
     }
 
     public function getDefaultTenant(Panel $panel): ?Model

--- a/app/Policies/ConnectedAccountPolicy.php
+++ b/app/Policies/ConnectedAccountPolicy.php
@@ -17,7 +17,7 @@ class ConnectedAccountPolicy
      */
     public function viewAny(User $user): bool
     {
-        return true;
+        return $user->currentTeam !== null;
     }
 
     /**
@@ -33,7 +33,7 @@ class ConnectedAccountPolicy
      */
     public function create(User $user): bool
     {
-        return true;
+        return $user->currentTeam !== null;
     }
 
     /**

--- a/app/Services/MenuService.php
+++ b/app/Services/MenuService.php
@@ -39,11 +39,25 @@ class MenuService
                 });
 
                 return SpatieMenu::new()
-                    ->add(Link::to($item->url, $item->name)->addClass('relative group'))
+                    ->add(Link::to($this->safeUrl($item->url), e($item->name))->addClass('relative group'))
                     ->add($submenu->addClass('hidden group-hover:block'));
             }
 
-            return Link::to($item->url, $item->name);
+            return Link::to($this->safeUrl($item->url), e($item->name));
         });
+    }
+
+    // Spatie\Menu\Link renders text and href raw (see vendor render()), so escape
+    // the user-supplied name with e() and reject dangerous URL schemes here.
+    private function safeUrl(?string $url): string
+    {
+        $url = (string) $url;
+        $scheme = strtolower((string) parse_url($url, PHP_URL_SCHEME));
+
+        if (in_array($scheme, ['javascript', 'data', 'vbscript'], true)) {
+            return '#';
+        }
+
+        return e($url);
     }
 }

--- a/config/fortify.php
+++ b/config/fortify.php
@@ -148,7 +148,7 @@ return [
     'features' => [
         Features::registration(),
         Features::resetPasswords(),
-        // Features::emailVerification(),
+        Features::emailVerification(),
         Features::updateProfileInformation(),
         Features::updatePasswords(),
         Features::twoFactorAuthentication([

--- a/resources/views/components/footer.blade.php
+++ b/resources/views/components/footer.blade.php
@@ -50,7 +50,7 @@
         <hr class="my-6 border-gray-200 sm:mx-auto dark:border-gray-700 lg:my-8"/>
         <div class="sm:flex sm:items-center sm:justify-between">
             <span class="text-sm text-gray-500 sm:text-center dark:text-gray-400">
-                {!! $footerCopyright !!}
+                {{ $footerCopyright }}
             </span>
             <div class="flex mt-4 space-x-6 sm:justify-center sm:mt-0">
                 @if($facebookUrl && $facebookUrl !== '#')


### PR DESCRIPTION
## Summary
Closes exploitable authorization, mass-assignment, and stored-XSS holes found in a security audit. SQL injection swept — clean, no changes.

Full test suite: **202 passed**. Pint clean.

## Authorization / IDOR
- `User::canAccessTenant()` — was hardcoded `return true` (any user reached any team's data); now enforces `ownedTeams->contains()`.
- `Api/TransactionController` — `index()` returned **all** users' transactions; now scoped to owner. Added ownership guards on `show/update/destroy`, set `user_id` on `store`.
- `TeamInvitationController` — invite now guarded by Jetstream `Team::hasUser()` (was: invite to any team).
- `ConnectedAccountPolicy` — `viewAny`/`create` were blind `true`; now require an active team.

## Mass assignment
Stripped ownership / secret / audit keys from `$fillable` (tokens, `credentials`, `is_approved`/`is_posted`, `reconciled_*`, `role`, `password`, balances, `user_id`) across `Account`, `BankConnection`, `ConnectedAccount`, `Customer`, `JournalEntry`, `TeamInvitation`, `Transaction`. Added `creating` hooks to backfill `user_id` so creation keeps working.

## Stored XSS
- `footer.blade.php` — admin-editable copyright now escaped `{{ }}`.
- `MenuService` — escape menu name + scheme-check url (blocks `javascript:`/`data:`).

## Email verification
- `canAccessPanel`/`canAccessFilament` require verified email.
- Enabled Fortify `emailVerification()`. Seeder + factory already set `email_verified_at`, so no lockout.

## Not included (deliberate)
- `password => 'hashed'` cast — breaks factories (pre-hashed strings); Fortify hashes on set anyway.
- Socialstream `createAccountOnFirstLogin`/`globalLogin` — shipped product feature, not a bug. `globalLogin()` worth a look if unverified-email providers are added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)