### PR TITLE
feat(api): invoices, bills, estimates REST endpoints (R7 remainder)

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -101,14 +101,17 @@ before finalizing.
 - [x] `ReconciliationService::reconcileStatement()` — single source of truth for the reconciled rule (no unmatched + zero discrepancy)
 - [x] Test: balanced → reconciled, discrepancy → stays open (`ReconciliationWorkflowTest`, 2 tests)
 
-### R7 · Core REST endpoints `#15` — partial (branch `feat/r7-rest-endpoints`)
+### R7 · Core REST endpoints `#15` — done (branches `feat/r7-rest-endpoints` + `feat/r7b-sales-purchase-api`)
 - [x] chart of accounts (`/api/chart-of-accounts`, full CRUD, Sanctum, user-scoped)
 - [x] journal entries (`/api/journal-entries`, index/store/show/destroy; store rejects unbalanced lines)
 - [x] general ledger (`/api/general-ledger/trial-balance` + `/balances`, read-only)
+- [x] invoices (`/api/invoices`, full CRUD, team-scoped)
+- [x] bills (`/api/bills`, full CRUD, team-scoped)
+- [x] estimates (`/api/estimates`, full CRUD, team-scoped)
 - [x] Apply existing rate-limit pattern (`throttle:60,1`)
-- [x] Tests per endpoint (`ChartOfAccountApiTest` 5, `JournalEntryApiTest` 5, `GeneralLedgerApiTest` 2)
-- [x] Fixed `GeneralLedgerService` null-currency crash + wrong `account_id` column in trial-balance/balances
-- [ ] invoices / bills / estimates — **deferred**: depend on R3's invoice fixes (str_pad boot bug, `invoice_number` column) + missing Bill/Estimate factories. Build once R3 (#786) merges to avoid duplicating it.
+- [x] Tests per endpoint (CoA 5, journal 5, GL 2, invoice 3, bill 3, estimate 3)
+- [x] Fixed `GeneralLedgerService` null-currency crash + wrong `account_id` column
+- [x] Fixed `str_pad(int)` boot bug in `Bill`/`Estimate` number generators; added `team_id` to fillable; new `Vendor`/`Bill`/`Estimate` factories
 
 ---
 

--- a/app/Http/Controllers/Api/BillController.php
+++ b/app/Http/Controllers/Api/BillController.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Bill;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Pagination\LengthAwarePaginator;
+
+class BillController extends Controller
+{
+    public function index(Request $request): LengthAwarePaginator
+    {
+        return Bill::where('team_id', $request->user()->current_team_id)
+            ->latest()
+            ->paginate(25);
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'vendor_id' => 'required|exists:vendors,vendor_id',
+            'bill_date' => 'required|date',
+            'due_date' => 'required|date',
+            'subtotal_amount' => 'sometimes|numeric',
+            'tax_amount' => 'sometimes|numeric',
+            'total_amount' => 'required|numeric',
+            'reference_number' => 'sometimes|nullable|string',
+            'notes' => 'sometimes|nullable|string',
+        ]);
+
+        $validated['team_id'] = $request->user()->current_team_id;
+
+        $bill = Bill::create($validated);
+
+        return response()->json($bill, 201);
+    }
+
+    public function show(Request $request, Bill $bill): JsonResponse
+    {
+        $this->authorizeTeam($request, $bill);
+
+        return response()->json($bill->load('items'));
+    }
+
+    public function update(Request $request, Bill $bill): JsonResponse
+    {
+        $this->authorizeTeam($request, $bill);
+
+        $validated = $request->validate([
+            'vendor_id' => 'sometimes|exists:vendors,vendor_id',
+            'bill_date' => 'sometimes|date',
+            'due_date' => 'sometimes|date',
+            'total_amount' => 'sometimes|numeric',
+            'status' => 'sometimes|string',
+            'payment_status' => 'sometimes|string',
+            'notes' => 'sometimes|nullable|string',
+        ]);
+
+        $bill->update($validated);
+
+        return response()->json($bill);
+    }
+
+    public function destroy(Request $request, Bill $bill): JsonResponse
+    {
+        $this->authorizeTeam($request, $bill);
+
+        $bill->delete();
+
+        return response()->json(['deleted' => true]);
+    }
+
+    private function authorizeTeam(Request $request, Bill $bill): void
+    {
+        abort_unless((int) $bill->team_id === (int) $request->user()->current_team_id, 403);
+    }
+}

--- a/app/Http/Controllers/Api/EstimateController.php
+++ b/app/Http/Controllers/Api/EstimateController.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Estimate;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Pagination\LengthAwarePaginator;
+
+class EstimateController extends Controller
+{
+    public function index(Request $request): LengthAwarePaginator
+    {
+        return Estimate::where('team_id', $request->user()->current_team_id)
+            ->latest()
+            ->paginate(25);
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'customer_id' => 'required|exists:customers,id',
+            'estimate_date' => 'required|date',
+            'expiration_date' => 'sometimes|nullable|date',
+            'subtotal_amount' => 'sometimes|numeric',
+            'tax_amount' => 'sometimes|numeric',
+            'total_amount' => 'required|numeric',
+            'status' => 'sometimes|string',
+            'notes' => 'sometimes|nullable|string',
+            'terms' => 'sometimes|nullable|string',
+        ]);
+
+        $validated['team_id'] = $request->user()->current_team_id;
+
+        $estimate = Estimate::create($validated);
+
+        return response()->json($estimate, 201);
+    }
+
+    public function show(Request $request, Estimate $estimate): JsonResponse
+    {
+        $this->authorizeTeam($request, $estimate);
+
+        return response()->json($estimate->load('items'));
+    }
+
+    public function update(Request $request, Estimate $estimate): JsonResponse
+    {
+        $this->authorizeTeam($request, $estimate);
+
+        $validated = $request->validate([
+            'customer_id' => 'sometimes|exists:customers,id',
+            'estimate_date' => 'sometimes|date',
+            'expiration_date' => 'sometimes|nullable|date',
+            'total_amount' => 'sometimes|numeric',
+            'status' => 'sometimes|string',
+            'notes' => 'sometimes|nullable|string',
+        ]);
+
+        $estimate->update($validated);
+
+        return response()->json($estimate);
+    }
+
+    public function destroy(Request $request, Estimate $estimate): JsonResponse
+    {
+        $this->authorizeTeam($request, $estimate);
+
+        $estimate->delete();
+
+        return response()->json(['deleted' => true]);
+    }
+
+    private function authorizeTeam(Request $request, Estimate $estimate): void
+    {
+        abort_unless((int) $estimate->team_id === (int) $request->user()->current_team_id, 403);
+    }
+}

--- a/app/Http/Controllers/Api/InvoiceController.php
+++ b/app/Http/Controllers/Api/InvoiceController.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Invoice;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Pagination\LengthAwarePaginator;
+
+class InvoiceController extends Controller
+{
+    public function index(Request $request): LengthAwarePaginator
+    {
+        return Invoice::where('team_id', $request->user()->current_team_id)
+            ->latest()
+            ->paginate(25);
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'customer_id' => 'required|exists:customers,id',
+            'vendor_id' => 'sometimes|nullable|exists:vendors,vendor_id',
+            'invoice_date' => 'required|date',
+            'due_date' => 'sometimes|nullable|date',
+            'total_amount' => 'required|numeric',
+            'payment_status' => 'required|string',
+            'notes' => 'sometimes|nullable|string',
+        ]);
+
+        $validated['team_id'] = $request->user()->current_team_id;
+
+        $invoice = Invoice::create($validated);
+
+        return response()->json($invoice, 201);
+    }
+
+    public function show(Request $request, Invoice $invoice): JsonResponse
+    {
+        $this->authorizeTeam($request, $invoice);
+
+        return response()->json($invoice->load('items'));
+    }
+
+    public function update(Request $request, Invoice $invoice): JsonResponse
+    {
+        $this->authorizeTeam($request, $invoice);
+
+        $validated = $request->validate([
+            'customer_id' => 'sometimes|exists:customers,id',
+            'invoice_date' => 'sometimes|date',
+            'due_date' => 'sometimes|nullable|date',
+            'total_amount' => 'sometimes|numeric',
+            'payment_status' => 'sometimes|string',
+            'notes' => 'sometimes|nullable|string',
+        ]);
+
+        $invoice->update($validated);
+
+        return response()->json($invoice);
+    }
+
+    public function destroy(Request $request, Invoice $invoice): JsonResponse
+    {
+        $this->authorizeTeam($request, $invoice);
+
+        $invoice->delete();
+
+        return response()->json(['deleted' => true]);
+    }
+
+    private function authorizeTeam(Request $request, Invoice $invoice): void
+    {
+        abort_unless((int) $invoice->team_id === (int) $request->user()->current_team_id, 403);
+    }
+}

--- a/app/Models/Bill.php
+++ b/app/Models/Bill.php
@@ -40,6 +40,7 @@ class Bill extends Model
         'approved_at',
         'approval_status',
         'rejection_reason',
+        'team_id',
     ];
 
     #[\Override]
@@ -249,6 +250,6 @@ class Bill extends Model
             $number = isset($parts[1]) ? ((int) $parts[1]) + 1 : 1;
         }
 
-        return $prefix.$year.'-'.str_pad($number, 4, '0', STR_PAD_LEFT);
+        return $prefix.$year.'-'.str_pad((string) $number, 4, '0', STR_PAD_LEFT);
     }
 }

--- a/app/Models/Estimate.php
+++ b/app/Models/Estimate.php
@@ -38,6 +38,7 @@ class Estimate extends Model
         'notes',
         'terms',
         'document_path',
+        'team_id',
     ];
 
     #[\Override]
@@ -256,6 +257,6 @@ class Estimate extends Model
             $number = isset($parts[1]) ? ((int) $parts[1]) + 1 : 1;
         }
 
-        return $prefix.$year.'-'.str_pad($number, 4, '0', STR_PAD_LEFT);
+        return $prefix.$year.'-'.str_pad((string) $number, 4, '0', STR_PAD_LEFT);
     }
 }

--- a/app/Models/Invoice.php
+++ b/app/Models/Invoice.php
@@ -40,6 +40,7 @@ class Invoice extends Model
         'approved_at',
         'document_path',
         'notes',
+        'team_id',
     ];
 
     #[\Override]

--- a/database/factories/BillFactory.php
+++ b/database/factories/BillFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\Bill;
+use App\Models\Vendor;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Bill>
+ */
+class BillFactory extends Factory
+{
+    protected $model = Bill::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'vendor_id' => Vendor::factory(),
+            'bill_date' => now()->toDateString(),
+            'due_date' => now()->addDays(30)->toDateString(),
+            'total_amount' => $this->faker->randomFloat(2, 10, 5000),
+        ];
+    }
+}

--- a/database/factories/EstimateFactory.php
+++ b/database/factories/EstimateFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\Customer;
+use App\Models\Estimate;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Estimate>
+ */
+class EstimateFactory extends Factory
+{
+    protected $model = Estimate::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'customer_id' => Customer::factory(),
+            'estimate_date' => now()->toDateString(),
+            'expiration_date' => now()->addDays(30)->toDateString(),
+            'total_amount' => $this->faker->randomFloat(2, 10, 5000),
+        ];
+    }
+}

--- a/database/factories/VendorFactory.php
+++ b/database/factories/VendorFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\Vendor;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Vendor>
+ */
+class VendorFactory extends Factory
+{
+    protected $model = Vendor::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->company(),
+            'email' => $this->faker->unique()->companyEmail(),
+            'phone' => $this->faker->phoneNumber(),
+            'status' => 'active',
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,7 +1,10 @@
 <?php
 
+use App\Http\Controllers\Api\BillController;
 use App\Http\Controllers\Api\ChartOfAccountController;
+use App\Http\Controllers\Api\EstimateController;
 use App\Http\Controllers\Api\GeneralLedgerController;
+use App\Http\Controllers\Api\InvoiceController;
 use App\Http\Controllers\Api\JournalEntryController;
 use App\Http\Controllers\Api\PlaidController;
 use App\Http\Controllers\Api\PlaidWebhookController;
@@ -39,6 +42,9 @@ Route::middleware('auth:sanctum')->group(function (): void {
             ->only(['index', 'store', 'show', 'destroy']);
         Route::get('/general-ledger/trial-balance', [GeneralLedgerController::class, 'trialBalance']);
         Route::get('/general-ledger/balances', [GeneralLedgerController::class, 'balances']);
+        Route::apiResource('invoices', InvoiceController::class);
+        Route::apiResource('bills', BillController::class);
+        Route::apiResource('estimates', EstimateController::class);
     });
 
     Route::get('/exchange-rates', fn () => app(ExchangeRateService::class)->getLatestRates())->middleware('throttle:60,1');

--- a/tests/Feature/Api/BillApiTest.php
+++ b/tests/Feature/Api/BillApiTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Models\Bill;
+use App\Models\Team;
+use App\Models\User;
+use App\Models\Vendor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class BillApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    private int $teamId;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+        $team = Team::forceCreate(['user_id' => $this->user->id, 'name' => 'Test', 'personal_team' => true]);
+        $this->user->forceFill(['current_team_id' => $team->id])->save();
+        $this->teamId = $team->id;
+    }
+
+    public function test_index_requires_authentication(): void
+    {
+        $this->getJson('/api/bills')->assertUnauthorized();
+    }
+
+    public function test_store_creates_bill(): void
+    {
+        $vendor = Vendor::factory()->create();
+
+        $response = $this->actingAs($this->user)->postJson('/api/bills', [
+            'vendor_id' => $vendor->vendor_id,
+            'bill_date' => '2026-06-01',
+            'due_date' => '2026-06-30',
+            'total_amount' => 480.00,
+        ]);
+
+        $response->assertCreated();
+        $this->assertDatabaseHas('bills', ['vendor_id' => $vendor->vendor_id, 'total_amount' => 480.00]);
+    }
+
+    public function test_show_returns_bill(): void
+    {
+        $bill = Bill::factory()->create(['team_id' => $this->teamId]);
+
+        $this->actingAs($this->user)->getJson("/api/bills/{$bill->bill_id}")->assertOk();
+    }
+}

--- a/tests/Feature/Api/EstimateApiTest.php
+++ b/tests/Feature/Api/EstimateApiTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Models\Customer;
+use App\Models\Estimate;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class EstimateApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    private int $teamId;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+        $team = Team::forceCreate(['user_id' => $this->user->id, 'name' => 'Test', 'personal_team' => true]);
+        $this->user->forceFill(['current_team_id' => $team->id])->save();
+        $this->teamId = $team->id;
+    }
+
+    public function test_index_requires_authentication(): void
+    {
+        $this->getJson('/api/estimates')->assertUnauthorized();
+    }
+
+    public function test_store_creates_estimate(): void
+    {
+        $customer = Customer::factory()->create();
+
+        $response = $this->actingAs($this->user)->postJson('/api/estimates', [
+            'customer_id' => $customer->id,
+            'estimate_date' => '2026-06-01',
+            'total_amount' => 900.00,
+        ]);
+
+        $response->assertCreated();
+        $this->assertDatabaseHas('estimates', ['customer_id' => $customer->id, 'total_amount' => 900.00]);
+    }
+
+    public function test_show_returns_estimate(): void
+    {
+        $estimate = Estimate::factory()->create(['team_id' => $this->teamId]);
+
+        $this->actingAs($this->user)->getJson("/api/estimates/{$estimate->estimate_id}")->assertOk();
+    }
+}

--- a/tests/Feature/Api/InvoiceApiTest.php
+++ b/tests/Feature/Api/InvoiceApiTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Models\Customer;
+use App\Models\Invoice;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class InvoiceApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    private int $teamId;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+        $team = Team::forceCreate(['user_id' => $this->user->id, 'name' => 'Test', 'personal_team' => true]);
+        $this->user->forceFill(['current_team_id' => $team->id])->save();
+        $this->teamId = $team->id;
+    }
+
+    public function test_index_requires_authentication(): void
+    {
+        $this->getJson('/api/invoices')->assertUnauthorized();
+    }
+
+    public function test_store_creates_invoice(): void
+    {
+        $customer = Customer::factory()->create();
+
+        $response = $this->actingAs($this->user)->postJson('/api/invoices', [
+            'customer_id' => $customer->id,
+            'invoice_date' => '2026-06-01',
+            'due_date' => '2026-06-30',
+            'total_amount' => 250.00,
+            'payment_status' => 'pending',
+        ]);
+
+        $response->assertCreated()->assertJsonFragment(['total_amount' => '250.00']);
+        $this->assertDatabaseHas('invoices', ['customer_id' => $customer->id, 'total_amount' => 250.00]);
+    }
+
+    public function test_show_returns_invoice(): void
+    {
+        $invoice = Invoice::factory()->create(['team_id' => $this->teamId]);
+
+        $this->actingAs($this->user)->getJson("/api/invoices/{$invoice->id}")->assertOk();
+    }
+}


### PR DESCRIPTION
## R7 remainder — sales/purchase document endpoints

Completes R7 (the part deferred in #790 pending R3). With R3 merged, the invoice create path works; bills and estimates now have factories and their number-generator bugs fixed.

### Endpoints (all  + , team-scoped)
- **`/api/invoices`** — full CRUD
- **`/api/bills`** — full CRUD
- **`/api/estimates`** — full CRUD

### Fixes
- `str_pad(int)` `TypeError` in `Bill::generateBillNumber` and `Estimate::generateEstimateNumber` (PHP 8.5 strict types) — same class of bug R3 fixed for Invoice.
- Added `team_id` to `Invoice`/`Bill`/`Estimate` fillable so stores set tenancy (the `add_team_to_resources` column existed but wasn't mass-assignable).

### New factories
`VendorFactory`, `BillFactory`, `EstimateFactory`.

### Tests
- `InvoiceApiTest`, `BillApiTest`, `EstimateApiTest` (3 each — auth, store, show)
- Full suite: **242 passing**

Closes R7 in `TASKS.md`.