### PR TITLE
test(coverage): asset depreciation + HMRC PAYE/CT tests (R8)

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -117,12 +117,16 @@ before finalizing.
 
 ## P3 — Coverage
 
-### R8 · Test gaps `#12` `#17`
-- [ ] Inventory valuation/COGS tests
-- [ ] Asset depreciation schedule tests
-- [ ] HMRC PAYE/CT tests
-- [ ] Coverage for all R1–R7 deliverables
-- [ ] No core feature at 0 coverage
+### R8 · Test gaps `#12` `#17` — done (branch `feat/r8-coverage`)
+- [x] Inventory valuation/COGS tests (delivered in R5 — `InventoryValuationTest`)
+- [x] Asset depreciation schedule tests (`AssetDepreciationTest`, 3 — straight-line + reducing-balance + schedule)
+- [x] HMRC PAYE tests (`HmrcRtiPayeTest`, 2) + Corporation Tax tests (`HmrcCorporationTaxTest`, 2)
+- [x] Coverage for R1–R7 deliverables (each shipped with its own tests)
+- [x] No core feature at 0 coverage
+- Surfaced + fixed real bugs while testing:
+  - `assets` table migration mismatched the model (Asset was uncreatable) — schema corrected (PK `asset_id`, `asset_name`/`asset_cost`/`useful_life_years`) + dependent FKs
+  - `HmrcSubmission`/`HmrcCorporationTaxSubmission`/`HmrcPayeSubmission` `company()` used a bare `belongsTo` (Company PK is `company_id`) → relation always null → fixed
+  - `HmrcRtiPayeService` passed int `tax_month` to `SimpleXMLElement::addChild` (TypeError) → cast to string
 
 ---
 

--- a/app/Models/HmrcCorporationTaxSubmission.php
+++ b/app/Models/HmrcCorporationTaxSubmission.php
@@ -53,7 +53,9 @@ class HmrcCorporationTaxSubmission extends Model
      */
     public function company(): BelongsTo
     {
-        return $this->belongsTo(Company::class);
+        // Company's primary key is company_id; without explicit keys Laravel
+        // derives company_company_id and the relation is always null.
+        return $this->belongsTo(Company::class, 'company_id', 'company_id');
     }
 
     /**

--- a/app/Models/HmrcPayeSubmission.php
+++ b/app/Models/HmrcPayeSubmission.php
@@ -50,7 +50,9 @@ class HmrcPayeSubmission extends Model
      */
     public function company(): BelongsTo
     {
-        return $this->belongsTo(Company::class);
+        // Company's primary key is `company_id`; pass keys explicitly so Laravel
+        // doesn't derive the wrong foreign key (`company_company_id`) and return null.
+        return $this->belongsTo(Company::class, 'company_id', 'company_id');
     }
 
     /**

--- a/app/Models/HmrcSubmission.php
+++ b/app/Models/HmrcSubmission.php
@@ -44,7 +44,9 @@ class HmrcSubmission extends Model
      */
     public function company(): BelongsTo
     {
-        return $this->belongsTo(Company::class);
+        // Company's primary key is company_id; without explicit keys Laravel
+        // derives company_company_id and the relation is always null.
+        return $this->belongsTo(Company::class, 'company_id', 'company_id');
     }
 
     /**

--- a/app/Services/HmrcRtiPayeService.php
+++ b/app/Services/HmrcRtiPayeService.php
@@ -177,7 +177,7 @@ class HmrcRtiPayeService
         // Employment
         $employment = $fps->addChild('Employment');
         $employment->addChild('TaxYear', $payeSubmission->tax_year);
-        $employment->addChild('TaxMonth', $payeSubmission->tax_month);
+        $employment->addChild('TaxMonth', (string) $payeSubmission->tax_month);
         $employment->addChild('PaymentDate', $payeSubmission->payment_date->format('Y-m-d'));
 
         // Employer

--- a/database/migrations/2024_01_01_000002_create_assets_table.php
+++ b/database/migrations/2024_01_01_000002_create_assets_table.php
@@ -14,11 +14,11 @@ class CreateAssetsTable extends Migration
     public function up(): void
     {
         Schema::create('assets', function (Blueprint $table): void {
-            $table->id();
-            $table->foreignId('user_id')->constrained()->onDelete('cascade');
-            $table->string('name');
-            $table->decimal('value', 12, 2);
-            $table->date('acquired_at')->nullable();
+            // PK is asset_id to match App\Models\Asset::$primaryKey and the Filament AssetResource.
+            $table->id('asset_id');
+            $table->string('asset_name');
+            $table->decimal('asset_cost', 15, 2);
+            $table->integer('useful_life_years');
             $table->timestamps();
         });
     }

--- a/database/migrations/2024_02_14_000002_create_depreciation_calculations_table.php
+++ b/database/migrations/2024_02_14_000002_create_depreciation_calculations_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
     {
         Schema::create('depreciation_calculations', function (Blueprint $table): void {
             $table->id();
-            $table->foreignId('asset_id')->constrained('assets', 'id');
+            $table->foreignId('asset_id')->constrained('assets', 'asset_id');
             $table->integer('year');
             $table->decimal('depreciation_amount', 15, 2);
             $table->decimal('accumulated_depreciation', 15, 2);

--- a/database/migrations/2024_02_23_113340_create_asset_acquisitions_table.php
+++ b/database/migrations/2024_02_23_113340_create_asset_acquisitions_table.php
@@ -16,7 +16,7 @@ return new class extends Migration
             $table->date('acquisition_date');
             $table->decimal('acquisition_price', 10, 2);
             $table->timestamps();
-            $table->foreignId('asset_id')->constrained()->onDelete('cascade');
+            $table->foreignId('asset_id')->constrained('assets', 'asset_id')->onDelete('cascade');
         });
     }
 

--- a/tests/Feature/AssetDepreciationTest.php
+++ b/tests/Feature/AssetDepreciationTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Asset;
+use App\Models\DepreciationCalculation;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AssetDepreciationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function makeAsset(string $method, float $cost, float $salvage, int $life): Asset
+    {
+        return Asset::create([
+            'asset_name' => 'Test Asset',
+            'asset_cost' => $cost,
+            'useful_life_years' => $life,
+            'depreciation_method' => $method,
+            'salvage_value' => $salvage,
+            'acquisition_date' => '2024-01-01',
+            'is_active' => true,
+        ]);
+    }
+
+    /** Straight line: (cost - salvage) / life. 10000, salvage 1000, 5yr => 1800/yr. */
+    public function test_straight_line_annual_depreciation(): void
+    {
+        $asset = $this->makeAsset('straight_line', 10000, 1000, 5);
+        $asset->calculateDepreciation();
+
+        $rows = DepreciationCalculation::where('asset_id', $asset->asset_id)
+            ->orderBy('year')->get();
+
+        $this->assertCount(5, $rows);
+        $this->assertEqualsWithDelta(1800.0, (float) $rows[0]->depreciation_amount, 0.001);
+        $this->assertEqualsWithDelta(1800.0, (float) $rows[0]->accumulated_depreciation, 0.001);
+        $this->assertEqualsWithDelta(8200.0, (float) $rows[0]->book_value, 0.001);
+    }
+
+    /** Multi-period straight line: book value never drops below salvage; final accumulated = depreciable amount. */
+    public function test_straight_line_schedule_floors_at_salvage(): void
+    {
+        $asset = $this->makeAsset('straight_line', 10000, 1000, 5);
+        $asset->calculateDepreciation();
+
+        $rows = DepreciationCalculation::where('asset_id', $asset->asset_id)
+            ->orderBy('year')->get();
+
+        // After 3 of 5 years: accumulated 5400, book value 4600.
+        $this->assertEqualsWithDelta(5400.0, (float) $rows[2]->accumulated_depreciation, 0.001);
+        $this->assertEqualsWithDelta(4600.0, (float) $rows[2]->book_value, 0.001);
+
+        // Final year: fully depreciated to salvage.
+        $this->assertEqualsWithDelta(9000.0, (float) $rows[4]->accumulated_depreciation, 0.001);
+        $this->assertEqualsWithDelta(1000.0, (float) $rows[4]->book_value, 0.001);
+    }
+
+    /** Reducing balance (double declining): rate = 2/life. 10000, 5yr => 40% => first year 4000. */
+    public function test_reducing_balance_first_period(): void
+    {
+        $asset = $this->makeAsset('reducing_balance', 10000, 1000, 5);
+        $asset->calculateDepreciation();
+
+        $rows = DepreciationCalculation::where('asset_id', $asset->asset_id)
+            ->orderBy('year')->get();
+
+        // Year 1: 10000 * 0.4 = 4000, book value 6000.
+        $this->assertEqualsWithDelta(4000.0, (float) $rows[0]->depreciation_amount, 0.001);
+        $this->assertEqualsWithDelta(6000.0, (float) $rows[0]->book_value, 0.001);
+
+        // Year 2: 6000 * 0.4 = 2400, book value 3600, accumulated 6400.
+        $this->assertEqualsWithDelta(2400.0, (float) $rows[1]->depreciation_amount, 0.001);
+        $this->assertEqualsWithDelta(3600.0, (float) $rows[1]->book_value, 0.001);
+        $this->assertEqualsWithDelta(6400.0, (float) $rows[1]->accumulated_depreciation, 0.001);
+    }
+}

--- a/tests/Feature/HmrcCorporationTaxTest.php
+++ b/tests/Feature/HmrcCorporationTaxTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Company;
+use App\Models\HmrcCorporationTaxSubmission;
+use App\Services\HmrcAuthService;
+use App\Services\HmrcMtdCorporationTaxService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class HmrcCorporationTaxTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private HmrcMtdCorporationTaxService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Stub the HMRC OAuth token so no real auth call happens.
+        $authService = $this->createStub(HmrcAuthService::class);
+        $authService->method('getAccessToken')->willReturn('test-token');
+
+        $this->service = new HmrcMtdCorporationTaxService($authService);
+    }
+
+    private function submissionFor(Company $company): HmrcCorporationTaxSubmission
+    {
+        return HmrcCorporationTaxSubmission::create([
+            'company_id' => $company->company_id,
+            'accounting_period_start' => '2025-04-01',
+            'accounting_period_end' => '2026-03-31',
+            'turnover' => 500000,
+            'total_profits' => 120000,
+            'taxable_profits' => 120000,
+            'corporation_tax_charged' => 30000,
+            'marginal_relief' => 0,
+            'total_tax_payable' => 30000,
+            'computation_data' => ['note' => 'test'],
+            'filing_due_date' => '2027-03-31',
+            'payment_due_date' => '2027-01-01',
+            'is_amended' => false,
+        ]);
+    }
+
+    public function test_submits_computation_and_persists_submission_record(): void
+    {
+        $company = Company::factory()->create(['hmrc_corporation_tax_utr' => '1234567890']);
+        $ct = $this->submissionFor($company);
+
+        Http::fake([
+            '*/organisations/corporation-tax/*/computations' => Http::response([
+                'referenceNumber' => 'CT-REF-9001',
+            ], 200),
+        ]);
+
+        $response = $this->service->submitComputation($ct);
+
+        $this->assertSame('CT-REF-9001', $response['referenceNumber']);
+
+        Http::assertSent(fn ($request) => str_contains($request->url(), '/organisations/corporation-tax/1234567890/computations')
+            && $request->hasHeader('Authorization', 'Bearer test-token'));
+
+        $this->assertDatabaseHas('hmrc_submissions', [
+            'company_id' => $company->company_id,
+            'submission_type' => 'corporation_tax',
+            'hmrc_reference' => 'CT-REF-9001',
+        ]);
+
+        $this->assertNotNull($ct->fresh()->hmrc_submission_id);
+    }
+
+    public function test_throws_when_company_has_no_utr(): void
+    {
+        $this->expectException(\Exception::class);
+
+        $company = Company::factory()->create(['hmrc_corporation_tax_utr' => null]);
+
+        $this->service->submitComputation($this->submissionFor($company));
+    }
+}

--- a/tests/Feature/HmrcRtiPayeTest.php
+++ b/tests/Feature/HmrcRtiPayeTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Company;
+use App\Models\HmrcPayeSubmission;
+use App\Services\HmrcAuthService;
+use App\Services\HmrcRtiPayeService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class HmrcRtiPayeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected HmrcRtiPayeService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // HMRC OAuth token is provided by HmrcAuthService — stub it so no real auth call happens.
+        $authService = $this->createStub(HmrcAuthService::class);
+        $authService->method('getAccessToken')->willReturn('test-token');
+
+        $this->service = new HmrcRtiPayeService($authService);
+    }
+
+    public function test_submits_fps_and_persists_submission_record(): void
+    {
+        $company = Company::factory()->create([
+            'hmrc_paye_reference' => '123/AB12345',
+        ]);
+
+        $payeSubmission = HmrcPayeSubmission::create([
+            'company_id' => $company->company_id,
+            'tax_year' => '2023-24',
+            'tax_month' => '1',
+            'payment_date' => '2023-05-31',
+            'employee_count' => 1,
+            'employee_data' => [
+                [
+                    'name' => 'Jane Doe',
+                    'nino' => 'AB123456C',
+                    'gross_pay' => 2500.00,
+                    'paye_tax' => 300.00,
+                    'employee_ni' => 150.00,
+                    'employer_ni' => 200.00,
+                ],
+            ],
+        ]);
+
+        // HMRC RTI returns an XML envelope; fake it so we never hit the real endpoint.
+        Http::fake([
+            '*/organisations/paye/*/fps' => Http::response(
+                '<?xml version="1.0" encoding="UTF-8"?>'
+                .'<GovTalkMessage><Header><MessageDetails>'
+                .'<CorrelationID>RTI-CORR-123</CorrelationID>'
+                .'<Timestamp>2023-05-31T10:00:00</Timestamp>'
+                .'</MessageDetails></Header></GovTalkMessage>',
+                200,
+                ['Content-Type' => 'application/xml']
+            ),
+        ]);
+
+        $response = $this->service->submitFps($payeSubmission);
+
+        $this->assertTrue($response['success']);
+        $this->assertSame('RTI-CORR-123', $response['correlationId']);
+
+        // FPS request was actually sent with the bearer token.
+        Http::assertSent(fn ($request) => str_contains($request->url(), '/organisations/paye/123/AB12345/fps')
+            && $request->hasHeader('Authorization', 'Bearer test-token'));
+
+        // Submission row persisted and accepted.
+        $this->assertDatabaseHas('hmrc_submissions', [
+            'company_id' => $company->company_id,
+            'submission_type' => 'paye_rti',
+            'status' => 'accepted',
+            'hmrc_reference' => 'RTI-CORR-123',
+        ]);
+
+        // PAYE submission linked back to the created HMRC submission.
+        $payeSubmission->refresh();
+        $this->assertNotNull($payeSubmission->hmrc_submission_id);
+    }
+
+    public function test_throws_when_company_has_no_paye_reference(): void
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Company does not have a PAYE reference');
+
+        $company = Company::factory()->create(['hmrc_paye_reference' => null]);
+
+        $payeSubmission = HmrcPayeSubmission::create([
+            'company_id' => $company->company_id,
+            'tax_year' => '2023-24',
+            'tax_month' => 1,
+            'payment_date' => '2023-05-31',
+            'employee_data' => [['name' => 'Jane Doe', 'nino' => 'AB123456C']],
+        ]);
+
+        $this->service->submitFps($payeSubmission);
+    }
+}


### PR DESCRIPTION
## R8 — Test coverage (asset depreciation, HMRC PAYE/CT)

Closes the test-coverage gaps the audit flagged (`PRD.md`): fixed-asset depreciation and HMRC payroll/tax had zero/near-zero tests. Built with two parallel agents (asset + HMRC), each verifying its own file.

### Tests added
- **`AssetDepreciationTest`** (3) — straight-line (10000 / salvage 1000 / 5yr → 1800/yr), reducing-balance (double-declining 40%), multi-period schedule (accumulated depreciation + book value)
- **`HmrcRtiPayeTest`** (2) — RTI/FPS PAYE submission persists an `hmrc_submissions` row + guard path; HMRC faked via `Http::fake`
- **`HmrcCorporationTaxTest`** (2) — CT computation submission persists + guard path
- Inventory valuation/COGS already covered by R5's `InventoryValuationTest`

### Real bugs surfaced + fixed
- **`assets` table migration mismatched the `Asset` model** — wrong primary key, missing `useful_life_years` / `asset_cost` / `asset_name`. Asset was **uncreatable**. Schema corrected; dependent FKs (`depreciation_calculations`, `asset_acquisitions`) repointed to `assets.asset_id`.
- **`HmrcSubmission` / `HmrcCorporationTaxSubmission` / `HmrcPayeSubmission` `company()`** used a bare `belongsTo`, but `Company`'s PK is `company_id` — the relation was **always null**, so the submit paths could never run in production. Added explicit keys.
- **`HmrcRtiPayeService`** passed an int `tax_month` to `SimpleXMLElement::addChild` (`TypeError`) — cast to string.

### Result
Full suite: **249 passing**.

Closes R8 in `TASKS.md` — completes the entire PRD backlog (R1–R8).
