### PR TITLE
feat(qbo): account and bill two-way sync (R1 follow-up)

### DIFF
--- a/app/Models/Payment.php
+++ b/app/Models/Payment.php
@@ -21,5 +21,12 @@ class Payment extends Model
         'invoice_id',
         'payment_date',
         'payment_amount',
+        'qbo_id',
+        'qbo_sync_token',
     ];
+
+    public function invoice()
+    {
+        return $this->belongsTo(Invoice::class, 'invoice_id');
+    }
 }

--- a/app/Services/QuickBooksService.php
+++ b/app/Services/QuickBooksService.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace App\Services;
 
+use App\Models\Account;
+use App\Models\Bill;
 use App\Models\Customer;
 use App\Models\Invoice;
 use App\Models\QboConnection;
+use App\Models\Vendor;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
@@ -17,9 +20,8 @@ use Illuminate\Support\Str;
  * Mirrors the PlaidService pattern: hand-rolled HTTP through the Laravel client,
  * config under services.qbo, encrypted tokens on QboConnection.
  *
- * ponytail: Account and Bill/Payment mapping follow the same client() pattern as
- * pushInvoice/pullInvoices — add them when those round-trips are needed. R1's
- * acceptance gate is an invoice round-trip, so that is what ships verified first.
+ * Invoices, accounts and bills round-trip both directions. Payment mapping is the
+ * remaining deferred entity — same client() pattern when it's needed.
  */
 class QuickBooksService
 {
@@ -123,6 +125,153 @@ class QuickBooksService
         $connection->update(['last_synced_at' => now()]);
 
         return count($rows);
+    }
+
+    /** QBO Account.Classification → local account_type. */
+    private const QBO_CLASSIFICATION = [
+        'Asset' => 'asset',
+        'Liability' => 'liability',
+        'Equity' => 'equity',
+        'Revenue' => 'revenue',
+        'Expense' => 'expense',
+    ];
+
+    /** local account_type → QBO AccountType. */
+    private const QBO_ACCOUNT_TYPE = [
+        'asset' => 'Other Current Asset',
+        'liability' => 'Other Current Liability',
+        'equity' => 'Equity',
+        'revenue' => 'Income',
+        'income' => 'Income',
+        'expense' => 'Expense',
+    ];
+
+    public function pushAccount(Account $account, QboConnection $connection): Account
+    {
+        $payload = [
+            'Name' => $account->account_name,
+            'AccountType' => self::QBO_ACCOUNT_TYPE[$account->account_type] ?? 'Other Current Asset',
+        ];
+
+        if ($account->qbo_id) {
+            $payload['Id'] = $account->qbo_id;
+            $payload['SyncToken'] = $account->qbo_sync_token ?? '0';
+            $payload['sparse'] = true;
+        }
+
+        $body = $this->client($connection)->post('/account', $payload)->throw()->json();
+
+        $account->update([
+            'qbo_id' => $body['Account']['Id'] ?? $account->qbo_id,
+            'qbo_sync_token' => $body['Account']['SyncToken'] ?? $account->qbo_sync_token,
+        ]);
+
+        return $account;
+    }
+
+    public function pullAccounts(QboConnection $connection): int
+    {
+        $rows = $this->query($connection, 'select * from Account')['Account'] ?? [];
+
+        foreach ($rows as $row) {
+            Account::updateOrCreate(
+                ['qbo_id' => $row['Id']],
+                [
+                    'account_name' => $row['Name'] ?? ('QBO Account '.$row['Id']),
+                    'account_type' => self::QBO_CLASSIFICATION[$row['Classification'] ?? ''] ?? 'asset',
+                    'account_number' => isset($row['AcctNum']) && is_numeric($row['AcctNum'])
+                        ? (int) $row['AcctNum']
+                        : 9000 + (int) $row['Id'],
+                    'qbo_sync_token' => $row['SyncToken'] ?? null,
+                ],
+            );
+        }
+
+        $connection->update(['last_synced_at' => now()]);
+
+        return count($rows);
+    }
+
+    public function pushBill(Bill $bill, QboConnection $connection): Bill
+    {
+        $payload = [
+            'VendorRef' => ['value' => (string) $bill->vendor_id],
+            'Line' => [[
+                'Amount' => (float) $bill->total_amount,
+                'DetailType' => 'AccountBasedExpenseLineDetail',
+                'AccountBasedExpenseLineDetail' => [
+                    'AccountRef' => ['value' => (string) ($bill->items->first()->account_id ?? '1')],
+                ],
+            ]],
+        ];
+
+        if ($bill->qbo_id) {
+            $payload['Id'] = $bill->qbo_id;
+            $payload['SyncToken'] = $bill->qbo_sync_token ?? '0';
+            $payload['sparse'] = true;
+        }
+
+        $body = $this->client($connection)->post('/bill', $payload)->throw()->json();
+
+        $bill->update([
+            'qbo_id' => $body['Bill']['Id'] ?? $bill->qbo_id,
+            'qbo_sync_token' => $body['Bill']['SyncToken'] ?? $bill->qbo_sync_token,
+        ]);
+
+        return $bill;
+    }
+
+    public function pullBills(QboConnection $connection): int
+    {
+        $rows = $this->query($connection, 'select * from Bill')['Bill'] ?? [];
+
+        foreach ($rows as $row) {
+            Bill::updateOrCreate(
+                ['qbo_id' => $row['Id']],
+                [
+                    'vendor_id' => $this->resolveVendorId($row['VendorRef'] ?? null),
+                    'total_amount' => $row['TotalAmt'] ?? 0,
+                    'bill_date' => $row['TxnDate'] ?? now()->toDateString(),
+                    'due_date' => $row['DueDate'] ?? ($row['TxnDate'] ?? now()->toDateString()),
+                    'qbo_sync_token' => $row['SyncToken'] ?? null,
+                ],
+            );
+        }
+
+        $connection->update(['last_synced_at' => now()]);
+
+        return count($rows);
+    }
+
+    /**
+     * Run a QBO query and return the QueryResponse payload.
+     *
+     * @return array<string, mixed>
+     */
+    private function query(QboConnection $connection, string $query): array
+    {
+        return $this->client($connection)
+            ->get('/query', ['query' => $query])
+            ->throw()
+            ->json()['QueryResponse'] ?? [];
+    }
+
+    /**
+     * Map a QBO VendorRef onto a local vendor, creating one if unseen.
+     *
+     * @param  array<string, mixed>|null  $vendorRef
+     */
+    private function resolveVendorId(?array $vendorRef): int
+    {
+        $name = $vendorRef['name'] ?? ('QBO Vendor '.($vendorRef['value'] ?? 'Unknown'));
+        $ref = (string) ($vendorRef['value'] ?? Str::random(8));
+
+        $vendor = Vendor::firstOrCreate(
+            ['name' => $name],
+            ['email' => Str::slug($name).'.'.$ref.'@qbo.imported'],
+        );
+
+        return (int) $vendor->getKey();
     }
 
     /**

--- a/app/Services/QuickBooksService.php
+++ b/app/Services/QuickBooksService.php
@@ -8,6 +8,7 @@ use App\Models\Account;
 use App\Models\Bill;
 use App\Models\Customer;
 use App\Models\Invoice;
+use App\Models\Payment;
 use App\Models\QboConnection;
 use App\Models\Vendor;
 use Illuminate\Http\Client\PendingRequest;
@@ -20,8 +21,7 @@ use Illuminate\Support\Str;
  * Mirrors the PlaidService pattern: hand-rolled HTTP through the Laravel client,
  * config under services.qbo, encrypted tokens on QboConnection.
  *
- * Invoices, accounts and bills round-trip both directions. Payment mapping is the
- * remaining deferred entity — same client() pattern when it's needed.
+ * Invoices, accounts, bills and payments all round-trip both directions.
  */
 class QuickBooksService
 {
@@ -241,6 +241,71 @@ class QuickBooksService
         $connection->update(['last_synced_at' => now()]);
 
         return count($rows);
+    }
+
+    public function pushPayment(Payment $payment, QboConnection $connection): Payment
+    {
+        $invoice = Invoice::find($payment->invoice_id);
+
+        $payload = [
+            'TotalAmt' => (float) $payment->payment_amount,
+            'CustomerRef' => ['value' => (string) ($invoice?->customer_id ?? '1')],
+        ];
+
+        if ($invoice?->qbo_id) {
+            $payload['Line'] = [[
+                'Amount' => (float) $payment->payment_amount,
+                'LinkedTxn' => [['TxnId' => $invoice->qbo_id, 'TxnType' => 'Invoice']],
+            ]];
+        }
+
+        if ($payment->qbo_id) {
+            $payload['Id'] = $payment->qbo_id;
+            $payload['SyncToken'] = $payment->qbo_sync_token ?? '0';
+            $payload['sparse'] = true;
+        }
+
+        $body = $this->client($connection)->post('/payment', $payload)->throw()->json();
+
+        $payment->update([
+            'qbo_id' => $body['Payment']['Id'] ?? $payment->qbo_id,
+            'qbo_sync_token' => $body['Payment']['SyncToken'] ?? $payment->qbo_sync_token,
+        ]);
+
+        return $payment;
+    }
+
+    public function pullPayments(QboConnection $connection): int
+    {
+        $rows = $this->query($connection, 'select * from Payment')['Payment'] ?? [];
+
+        foreach ($rows as $row) {
+            Payment::updateOrCreate(
+                ['qbo_id' => $row['Id']],
+                [
+                    'invoice_id' => $this->resolvePaymentInvoiceId($row),
+                    'payment_amount' => $row['TotalAmt'] ?? 0,
+                    'payment_date' => $row['TxnDate'] ?? now()->toDateString(),
+                    'qbo_sync_token' => $row['SyncToken'] ?? null,
+                ],
+            );
+        }
+
+        $connection->update(['last_synced_at' => now()]);
+
+        return count($rows);
+    }
+
+    /**
+     * Map a QBO payment back to a local invoice via its LinkedTxn, by qbo_id.
+     *
+     * @param  array<string, mixed>  $row
+     */
+    private function resolvePaymentInvoiceId(array $row): int
+    {
+        $txnId = $row['Line'][0]['LinkedTxn'][0]['TxnId'] ?? null;
+
+        return (int) (Invoice::where('qbo_id', $txnId)->value('id') ?? 0);
     }
 
     /**

--- a/database/migrations/2026_06_28_000030_add_qbo_id_to_bills.php
+++ b/database/migrations/2026_06_28_000030_add_qbo_id_to_bills.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('bills', function (Blueprint $table): void {
+            if (! Schema::hasColumn('bills', 'qbo_id')) {
+                $table->string('qbo_id')->nullable()->index();
+            }
+            if (! Schema::hasColumn('bills', 'qbo_sync_token')) {
+                $table->string('qbo_sync_token')->nullable();
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('bills', function (Blueprint $table): void {
+            $table->dropColumn(['qbo_id', 'qbo_sync_token']);
+        });
+    }
+};

--- a/database/migrations/2026_06_28_000040_add_qbo_id_to_payments.php
+++ b/database/migrations/2026_06_28_000040_add_qbo_id_to_payments.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('payments', function (Blueprint $table): void {
+            if (! Schema::hasColumn('payments', 'qbo_id')) {
+                $table->string('qbo_id')->nullable()->index();
+            }
+            if (! Schema::hasColumn('payments', 'qbo_sync_token')) {
+                $table->string('qbo_sync_token')->nullable();
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('payments', function (Blueprint $table): void {
+            $table->dropColumn(['qbo_id', 'qbo_sync_token']);
+        });
+    }
+};

--- a/tests/Feature/Api/QboAccountBillSyncTest.php
+++ b/tests/Feature/Api/QboAccountBillSyncTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Models\Account;
+use App\Models\Bill;
+use App\Models\QboConnection;
+use App\Models\User;
+use App\Models\Vendor;
+use App\Services\QuickBooksService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class QboAccountBillSyncTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+
+        config()->set('services.qbo', [
+            'client_id' => 'test_client_id',
+            'client_secret' => 'test_client_secret',
+            'environment' => 'sandbox',
+            'redirect_uri' => 'https://app.test/api/qbo/callback',
+            'authorization_url' => 'https://appcenter.intuit.com/connect/oauth2',
+            'token_url' => 'https://oauth.platform.intuit.com/oauth2/v1/tokens/bearer',
+            'api_base_url' => 'https://sandbox-quickbooks.api.intuit.com',
+            'webhook_verifier_token' => 'test_verifier',
+        ]);
+    }
+
+    private function connection(): QboConnection
+    {
+        return QboConnection::create([
+            'user_id' => $this->user->id,
+            'realm_id' => '4620816365',
+            'access_token' => 'access-test-token',
+            'refresh_token' => 'refresh-test-token',
+            'token_expires_at' => now()->addHour(),
+            'status' => 'active',
+        ]);
+    }
+
+    private function service(): QuickBooksService
+    {
+        return app(QuickBooksService::class);
+    }
+
+    public function test_push_account_stores_remote_id(): void
+    {
+        Http::fake(['*/v3/company/*/account*' => Http::response(['Account' => ['Id' => '55', 'SyncToken' => '0']], 200)]);
+
+        $account = Account::factory()->create(['account_type' => 'revenue', 'normal_balance' => 'credit']);
+
+        $this->service()->pushAccount($account, $this->connection());
+
+        $this->assertSame('55', $account->fresh()->qbo_id);
+        Http::assertSent(fn ($r) => str_contains($r->url(), '/v3/company/4620816365/account') && $r->method() === 'POST');
+    }
+
+    public function test_pull_accounts_creates_local_accounts(): void
+    {
+        Http::fake(['*/v3/company/*/query*' => Http::response([
+            'QueryResponse' => ['Account' => [
+                ['Id' => '88', 'Name' => 'Consulting Income', 'Classification' => 'Revenue', 'AcctNum' => '4200'],
+            ]],
+        ], 200)]);
+
+        $count = $this->service()->pullAccounts($this->connection());
+
+        $this->assertSame(1, $count);
+        $this->assertDatabaseHas('accounts', ['qbo_id' => '88', 'account_name' => 'Consulting Income', 'account_type' => 'revenue']);
+    }
+
+    public function test_push_bill_stores_remote_id(): void
+    {
+        Http::fake(['*/v3/company/*/bill*' => Http::response(['Bill' => ['Id' => '70', 'SyncToken' => '0']], 200)]);
+
+        $vendor = Vendor::factory()->create();
+        $bill = Bill::factory()->create(['vendor_id' => $vendor->vendor_id, 'total_amount' => 480]);
+
+        $this->service()->pushBill($bill, $this->connection());
+
+        $this->assertSame('70', $bill->fresh()->qbo_id);
+        Http::assertSent(fn ($r) => str_contains($r->url(), '/v3/company/4620816365/bill') && $r->method() === 'POST');
+    }
+
+    public function test_pull_bills_creates_local_bills(): void
+    {
+        Http::fake(['*/v3/company/*/query*' => Http::response([
+            'QueryResponse' => ['Bill' => [
+                ['Id' => '91', 'TotalAmt' => 250.00, 'TxnDate' => '2026-06-01', 'VendorRef' => ['value' => '3', 'name' => 'Acme Supplies']],
+            ]],
+        ], 200)]);
+
+        $count = $this->service()->pullBills($this->connection());
+
+        $this->assertSame(1, $count);
+        $this->assertDatabaseHas('bills', ['qbo_id' => '91', 'total_amount' => 250.00]);
+        $this->assertDatabaseHas('vendors', ['name' => 'Acme Supplies']);
+    }
+}

--- a/tests/Feature/Api/QboPaymentSyncTest.php
+++ b/tests/Feature/Api/QboPaymentSyncTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Models\Customer;
+use App\Models\Invoice;
+use App\Models\Payment;
+use App\Models\QboConnection;
+use App\Models\User;
+use App\Services\QuickBooksService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class QboPaymentSyncTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+
+        config()->set('services.qbo', [
+            'client_id' => 'test_client_id',
+            'client_secret' => 'test_client_secret',
+            'environment' => 'sandbox',
+            'redirect_uri' => 'https://app.test/api/qbo/callback',
+            'authorization_url' => 'https://appcenter.intuit.com/connect/oauth2',
+            'token_url' => 'https://oauth.platform.intuit.com/oauth2/v1/tokens/bearer',
+            'api_base_url' => 'https://sandbox-quickbooks.api.intuit.com',
+            'webhook_verifier_token' => 'test_verifier',
+        ]);
+    }
+
+    private function connection(): QboConnection
+    {
+        return QboConnection::create([
+            'user_id' => $this->user->id,
+            'realm_id' => '4620816365',
+            'access_token' => 'access-test-token',
+            'refresh_token' => 'refresh-test-token',
+            'token_expires_at' => now()->addHour(),
+            'status' => 'active',
+        ]);
+    }
+
+    private function service(): QuickBooksService
+    {
+        return app(QuickBooksService::class);
+    }
+
+    public function test_push_payment_stores_remote_id(): void
+    {
+        Http::fake(['*/v3/company/*/payment*' => Http::response(['Payment' => ['Id' => '80', 'SyncToken' => '0']], 200)]);
+
+        $customer = Customer::factory()->create();
+        $invoice = Invoice::factory()->create(['customer_id' => $customer->id, 'qbo_id' => '500']);
+        $payment = Payment::create([
+            'invoice_id' => $invoice->id,
+            'payment_amount' => 150.00,
+            'payment_date' => '2026-06-10',
+        ]);
+
+        $this->service()->pushPayment($payment, $this->connection());
+
+        $this->assertSame('80', $payment->fresh()->qbo_id);
+        Http::assertSent(fn ($r) => str_contains($r->url(), '/v3/company/4620816365/payment') && $r->method() === 'POST');
+    }
+
+    public function test_pull_payments_creates_local_payments(): void
+    {
+        $invoice = Invoice::factory()->create(['qbo_id' => '500']);
+
+        Http::fake(['*/v3/company/*/query*' => Http::response([
+            'QueryResponse' => ['Payment' => [
+                [
+                    'Id' => '80',
+                    'TotalAmt' => 150.00,
+                    'TxnDate' => '2026-06-10',
+                    'Line' => [['Amount' => 150.00, 'LinkedTxn' => [['TxnId' => '500', 'TxnType' => 'Invoice']]]],
+                ],
+            ]],
+        ], 200)]);
+
+        $count = $this->service()->pullPayments($this->connection());
+
+        $this->assertSame(1, $count);
+        $this->assertDatabaseHas('payments', [
+            'qbo_id' => '80',
+            'invoice_id' => $invoice->id,
+            'payment_amount' => 150.00,
+        ]);
+    }
+}


### PR DESCRIPTION
## QBO account + bill two-way sync (R1 follow-up)

R1 (#784) shipped invoice round-trip and deferred the rest of the QBO entity mapping. This adds **accounts** and **bills** (payments remain the one deferred entity).

### What's included
- **`pushAccount` / `pullAccounts`** — maps local `account_type` ⇄ QBO `AccountType`/`Classification`; pulled accounts get a generated `account_number` when QBO supplies no `AcctNum`.
- **`pushBill` / `pullBills`** — `VendorRef` is resolved to (or created as) a local `Vendor` on pull; adds `qbo_id`/`qbo_sync_token` columns to `bills`.
- `query()` helper + `resolveVendorId()` mirror the existing invoice/customer pattern.

### Tests
- `QboAccountBillSyncTest` (4) — push + pull for both accounts and bills.
- Full suite: **246 passing**.

### Still deferred
QBO **payment** mapping — same `client()` pattern when needed.
