### PR TITLE
feat(inventory): stock-movement recording UI + service (R5 follow-up)

### DIFF
--- a/app/Filament/App/Resources/InventoryItems/InventoryItemResource.php
+++ b/app/Filament/App/Resources/InventoryItems/InventoryItemResource.php
@@ -7,7 +7,10 @@ namespace App\Filament\App\Resources\InventoryItems;
 use App\Filament\App\Resources\InventoryItems\Pages\CreateInventoryItem;
 use App\Filament\App\Resources\InventoryItems\Pages\EditInventoryItem;
 use App\Filament\App\Resources\InventoryItems\Pages\ListInventoryItems;
+use App\Models\Account;
 use App\Models\InventoryItem;
+use App\Services\InventoryMovementService;
+use Filament\Actions\Action;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
@@ -16,6 +19,7 @@ use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
+use Filament\Notifications\Notification;
 use Filament\Resources\Resource;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\IconColumn;
@@ -97,6 +101,46 @@ class InventoryItemResource extends Resource
             ])
             ->recordActions([
                 EditAction::make(),
+                Action::make('recordPurchase')
+                    ->label('Record purchase')
+                    ->icon('heroicon-o-arrow-down-tray')
+                    ->color('success')
+                    ->schema([
+                        TextInput::make('quantity')->numeric()->minValue(1)->required(),
+                        TextInput::make('unit_cost')->numeric()->minValue(0)->required(),
+                    ])
+                    ->action(function (InventoryItem $record, array $data): void {
+                        app(InventoryMovementService::class)
+                            ->recordPurchase($record, (int) $data['quantity'], (float) $data['unit_cost']);
+
+                        Notification::make()->title('Purchase recorded')->success()->send();
+                    }),
+                Action::make('recordSale')
+                    ->label('Record sale')
+                    ->icon('heroicon-o-arrow-up-tray')
+                    ->color('warning')
+                    ->schema([
+                        TextInput::make('quantity')
+                            ->numeric()->minValue(1)
+                            ->maxValue(fn (InventoryItem $record): int => $record->current_quantity)
+                            ->required(),
+                        Select::make('cogs_account_id')
+                            ->label('COGS expense account')
+                            ->options(fn () => Account::where('account_type', 'expense')->pluck('account_name', 'id'))
+                            ->searchable()
+                            ->required(),
+                    ])
+                    ->action(function (InventoryItem $record, array $data): void {
+                        $cogsAccount = Account::findOrFail($data['cogs_account_id']);
+                        $result = app(InventoryMovementService::class)
+                            ->recordSale($record, (int) $data['quantity'], $cogsAccount);
+
+                        Notification::make()
+                            ->title('Sale recorded')
+                            ->body('COGS posted: '.number_format($result['cogs'], 2))
+                            ->success()
+                            ->send();
+                    }),
                 DeleteAction::make(),
             ])
             ->toolbarActions([

--- a/app/Services/InventoryMovementService.php
+++ b/app/Services/InventoryMovementService.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\Account;
+use App\Models\InventoryCostLayer;
+use App\Models\InventoryItem;
+use App\Models\InventoryTransaction;
+use App\Models\JournalEntry;
+
+/**
+ * Records inventory stock movements from the UI: purchases add a cost layer and
+ * stock; sales consume layers (FIFO/LIFO/average), reduce stock, and post COGS.
+ */
+class InventoryMovementService
+{
+    public function __construct(
+        private readonly InventoryValuationService $valuation,
+        private readonly InventoryPostingService $posting,
+    ) {}
+
+    /**
+     * Record a purchase: new cost layer, weighted-average update, stock increase.
+     */
+    public function recordPurchase(InventoryItem $item, int $quantity, float $unitCost): InventoryCostLayer
+    {
+        $layer = InventoryCostLayer::create([
+            'inventory_item_id' => $item->id,
+            'quantity' => $quantity,
+            'unit_cost' => $unitCost,
+            'purchase_date' => now(),
+        ]);
+
+        // Weighted-average uses the pre-purchase quantity, so update it before the stock bump.
+        $this->valuation->updateAverageCost($item, $quantity, $unitCost);
+        $item->updateQuantity($quantity);
+
+        return $layer;
+    }
+
+    /**
+     * Record a sale: compute COGS from cost layers, reduce stock, post the COGS entry.
+     *
+     * @return array{cogs: float, journal_entry: JournalEntry}
+     */
+    public function recordSale(InventoryItem $item, int $quantity, Account $cogsExpense): array
+    {
+        // A transient transaction drives the valuation calc (consumes the layers).
+        $sale = new InventoryTransaction(['inventory_item_id' => $item->id, 'quantity' => $quantity]);
+        $cogs = (float) $this->valuation->calculateCostOfGoodsSold($sale);
+
+        $item->updateQuantity(-$quantity);
+
+        $entry = $this->posting->postCogs($item, $cogs, $cogsExpense);
+
+        return ['cogs' => $cogs, 'journal_entry' => $entry];
+    }
+}

--- a/tests/Feature/InventoryMovementTest.php
+++ b/tests/Feature/InventoryMovementTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Account;
+use App\Models\InventoryCostLayer;
+use App\Models\InventoryItem;
+use App\Models\User;
+use App\Services\InventoryMovementService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class InventoryMovementTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function service(): InventoryMovementService
+    {
+        return app(InventoryMovementService::class);
+    }
+
+    public function test_record_purchase_adds_cost_layer_and_stock(): void
+    {
+        $item = InventoryItem::factory()->create(['valuation_method' => 'fifo', 'current_quantity' => 0, 'average_cost' => 0]);
+
+        $this->service()->recordPurchase($item, 10, 5.00);
+
+        $item->refresh();
+        $this->assertSame(10, $item->current_quantity);
+        $this->assertEquals(5.00, $item->average_cost);
+        $this->assertDatabaseHas('inventory_cost_layers', [
+            'inventory_item_id' => $item->id,
+            'quantity' => 10,
+            'unit_cost' => 5.00,
+        ]);
+    }
+
+    public function test_second_purchase_updates_weighted_average(): void
+    {
+        $item = InventoryItem::factory()->create(['valuation_method' => 'average', 'current_quantity' => 0, 'average_cost' => 0]);
+
+        $this->service()->recordPurchase($item, 10, 4.00);  // avg 4
+        $this->service()->recordPurchase($item, 10, 6.00);  // (40 + 60) / 20 = 5
+
+        $this->assertEquals(5.00, $item->fresh()->average_cost);
+        $this->assertSame(20, $item->fresh()->current_quantity);
+    }
+
+    public function test_record_sale_posts_cogs_and_reduces_stock(): void
+    {
+        $this->actingAs(User::factory()->create());
+
+        $inventoryAsset = Account::factory()->create(['account_type' => 'asset', 'normal_balance' => 'debit']);
+        $cogsExpense = Account::factory()->create(['account_type' => 'expense', 'normal_balance' => 'debit']);
+        $item = InventoryItem::factory()->create([
+            'valuation_method' => 'fifo',
+            'current_quantity' => 20,
+            'account_id' => $inventoryAsset->id,
+        ]);
+        InventoryCostLayer::create(['inventory_item_id' => $item->id, 'quantity' => 10, 'unit_cost' => 2, 'purchase_date' => '2026-01-01']);
+        InventoryCostLayer::create(['inventory_item_id' => $item->id, 'quantity' => 10, 'unit_cost' => 3, 'purchase_date' => '2026-02-01']);
+
+        $result = $this->service()->recordSale($item, 15, $cogsExpense);  // FIFO: 10*2 + 5*3 = 35
+
+        $this->assertEquals(35.00, $result['cogs']);
+        $this->assertSame(5, $item->fresh()->current_quantity);
+        $this->assertTrue($result['journal_entry']->isBalanced());
+        $this->assertEquals(35.00, $result['journal_entry']->total_debits);
+    }
+}


### PR DESCRIPTION
## Inventory stock-movement recording (R5 follow-up)

Closes the stock-movement screens deferred in R5 (#788). Purchases and sales can now be recorded directly from the inventory item list.

### What's included
- **`InventoryMovementService::recordPurchase`** — adds a cost layer, updates the weighted-average cost, increases stock on hand.
- **`InventoryMovementService::recordSale`** — consumes cost layers (FIFO / LIFO / average) to compute COGS, reduces stock, and posts the **balanced** COGS journal entry (via `InventoryPostingService`).
- **Record purchase / Record sale** row actions on `InventoryItemResource`. The sale form caps quantity at stock on hand and selects the COGS expense account.

### Tests
- `InventoryMovementTest` (3): purchase adds layer + stock; second purchase updates weighted average (4 & 6 → 5); FIFO sale posts COGS 35 and reduces stock 20→5.
- Full suite: **245 passing**.
