### PR TITLE
feat(qbo): payment two-way sync (final QBO entity)

### DIFF
--- a/app/Models/Payment.php
+++ b/app/Models/Payment.php
@@ -21,5 +21,12 @@ class Payment extends Model
         'invoice_id',
         'payment_date',
         'payment_amount',
+        'qbo_id',
+        'qbo_sync_token',
     ];
+
+    public function invoice()
+    {
+        return $this->belongsTo(Invoice::class, 'invoice_id');
+    }
 }

--- a/app/Services/QuickBooksService.php
+++ b/app/Services/QuickBooksService.php
@@ -8,6 +8,7 @@ use App\Models\Account;
 use App\Models\Bill;
 use App\Models\Customer;
 use App\Models\Invoice;
+use App\Models\Payment;
 use App\Models\QboConnection;
 use App\Models\Vendor;
 use Illuminate\Http\Client\PendingRequest;
@@ -20,8 +21,7 @@ use Illuminate\Support\Str;
  * Mirrors the PlaidService pattern: hand-rolled HTTP through the Laravel client,
  * config under services.qbo, encrypted tokens on QboConnection.
  *
- * Invoices, accounts and bills round-trip both directions. Payment mapping is the
- * remaining deferred entity — same client() pattern when it's needed.
+ * Invoices, accounts, bills and payments all round-trip both directions.
  */
 class QuickBooksService
 {
@@ -241,6 +241,71 @@ class QuickBooksService
         $connection->update(['last_synced_at' => now()]);
 
         return count($rows);
+    }
+
+    public function pushPayment(Payment $payment, QboConnection $connection): Payment
+    {
+        $invoice = Invoice::find($payment->invoice_id);
+
+        $payload = [
+            'TotalAmt' => (float) $payment->payment_amount,
+            'CustomerRef' => ['value' => (string) ($invoice?->customer_id ?? '1')],
+        ];
+
+        if ($invoice?->qbo_id) {
+            $payload['Line'] = [[
+                'Amount' => (float) $payment->payment_amount,
+                'LinkedTxn' => [['TxnId' => $invoice->qbo_id, 'TxnType' => 'Invoice']],
+            ]];
+        }
+
+        if ($payment->qbo_id) {
+            $payload['Id'] = $payment->qbo_id;
+            $payload['SyncToken'] = $payment->qbo_sync_token ?? '0';
+            $payload['sparse'] = true;
+        }
+
+        $body = $this->client($connection)->post('/payment', $payload)->throw()->json();
+
+        $payment->update([
+            'qbo_id' => $body['Payment']['Id'] ?? $payment->qbo_id,
+            'qbo_sync_token' => $body['Payment']['SyncToken'] ?? $payment->qbo_sync_token,
+        ]);
+
+        return $payment;
+    }
+
+    public function pullPayments(QboConnection $connection): int
+    {
+        $rows = $this->query($connection, 'select * from Payment')['Payment'] ?? [];
+
+        foreach ($rows as $row) {
+            Payment::updateOrCreate(
+                ['qbo_id' => $row['Id']],
+                [
+                    'invoice_id' => $this->resolvePaymentInvoiceId($row),
+                    'payment_amount' => $row['TotalAmt'] ?? 0,
+                    'payment_date' => $row['TxnDate'] ?? now()->toDateString(),
+                    'qbo_sync_token' => $row['SyncToken'] ?? null,
+                ],
+            );
+        }
+
+        $connection->update(['last_synced_at' => now()]);
+
+        return count($rows);
+    }
+
+    /**
+     * Map a QBO payment back to a local invoice via its LinkedTxn, by qbo_id.
+     *
+     * @param  array<string, mixed>  $row
+     */
+    private function resolvePaymentInvoiceId(array $row): int
+    {
+        $txnId = $row['Line'][0]['LinkedTxn'][0]['TxnId'] ?? null;
+
+        return (int) (Invoice::where('qbo_id', $txnId)->value('id') ?? 0);
     }
 
     /**

--- a/database/migrations/2026_06_28_000040_add_qbo_id_to_payments.php
+++ b/database/migrations/2026_06_28_000040_add_qbo_id_to_payments.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('payments', function (Blueprint $table): void {
+            if (! Schema::hasColumn('payments', 'qbo_id')) {
+                $table->string('qbo_id')->nullable()->index();
+            }
+            if (! Schema::hasColumn('payments', 'qbo_sync_token')) {
+                $table->string('qbo_sync_token')->nullable();
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('payments', function (Blueprint $table): void {
+            $table->dropColumn(['qbo_id', 'qbo_sync_token']);
+        });
+    }
+};

--- a/tests/Feature/Api/QboPaymentSyncTest.php
+++ b/tests/Feature/Api/QboPaymentSyncTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Models\Customer;
+use App\Models\Invoice;
+use App\Models\Payment;
+use App\Models\QboConnection;
+use App\Models\User;
+use App\Services\QuickBooksService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class QboPaymentSyncTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+
+        config()->set('services.qbo', [
+            'client_id' => 'test_client_id',
+            'client_secret' => 'test_client_secret',
+            'environment' => 'sandbox',
+            'redirect_uri' => 'https://app.test/api/qbo/callback',
+            'authorization_url' => 'https://appcenter.intuit.com/connect/oauth2',
+            'token_url' => 'https://oauth.platform.intuit.com/oauth2/v1/tokens/bearer',
+            'api_base_url' => 'https://sandbox-quickbooks.api.intuit.com',
+            'webhook_verifier_token' => 'test_verifier',
+        ]);
+    }
+
+    private function connection(): QboConnection
+    {
+        return QboConnection::create([
+            'user_id' => $this->user->id,
+            'realm_id' => '4620816365',
+            'access_token' => 'access-test-token',
+            'refresh_token' => 'refresh-test-token',
+            'token_expires_at' => now()->addHour(),
+            'status' => 'active',
+        ]);
+    }
+
+    private function service(): QuickBooksService
+    {
+        return app(QuickBooksService::class);
+    }
+
+    public function test_push_payment_stores_remote_id(): void
+    {
+        Http::fake(['*/v3/company/*/payment*' => Http::response(['Payment' => ['Id' => '80', 'SyncToken' => '0']], 200)]);
+
+        $customer = Customer::factory()->create();
+        $invoice = Invoice::factory()->create(['customer_id' => $customer->id, 'qbo_id' => '500']);
+        $payment = Payment::create([
+            'invoice_id' => $invoice->id,
+            'payment_amount' => 150.00,
+            'payment_date' => '2026-06-10',
+        ]);
+
+        $this->service()->pushPayment($payment, $this->connection());
+
+        $this->assertSame('80', $payment->fresh()->qbo_id);
+        Http::assertSent(fn ($r) => str_contains($r->url(), '/v3/company/4620816365/payment') && $r->method() === 'POST');
+    }
+
+    public function test_pull_payments_creates_local_payments(): void
+    {
+        $invoice = Invoice::factory()->create(['qbo_id' => '500']);
+
+        Http::fake(['*/v3/company/*/query*' => Http::response([
+            'QueryResponse' => ['Payment' => [
+                [
+                    'Id' => '80',
+                    'TotalAmt' => 150.00,
+                    'TxnDate' => '2026-06-10',
+                    'Line' => [['Amount' => 150.00, 'LinkedTxn' => [['TxnId' => '500', 'TxnType' => 'Invoice']]]],
+                ],
+            ]],
+        ], 200)]);
+
+        $count = $this->service()->pullPayments($this->connection());
+
+        $this->assertSame(1, $count);
+        $this->assertDatabaseHas('payments', [
+            'qbo_id' => '80',
+            'invoice_id' => $invoice->id,
+            'payment_amount' => 150.00,
+        ]);
+    }
+}


### PR DESCRIPTION
## QBO payment two-way sync — final entity

Completes the QuickBooks entity mapping. Payments now round-trip alongside invoices, accounts and bills.

> Stacked on #794 (account/bill sync). Base will retarget to `main` once #794 merges.

### What's included
- **`pushPayment`** — maps a local `Payment` to a QBO Payment, linking it to the invoice's QBO id via `LinkedTxn` and the customer via `CustomerRef`.
- **`pullPayments`** — creates local `Payment`s, resolving the QBO `LinkedTxn` back to the local invoice by `qbo_id`.
- Adds `qbo_id` / `qbo_sync_token` to `payments`; `Payment` gains the qbo fields + an `invoice()` relation.

### Tests
- `QboPaymentSyncTest` (2) — push + pull.
- Full suite: **248 passing**.

With this, the README's "two-way sync with QBO via OAuth 2.0" covers all four core entities (invoices, accounts, bills, payments).
