### PR TITLE
fix(currency): create exchange_rates table + implement getLatestRates

### DIFF
--- a/app/Services/ExchangeRateService.php
+++ b/app/Services/ExchangeRateService.php
@@ -48,6 +48,27 @@ class ExchangeRateService
         }
     }
 
+    /**
+     * The most recent rate for each currency pair, newest first.
+     *
+     * @return list<array{from: ?string, to: ?string, rate: float, date: ?string}>
+     */
+    public function getLatestRates(): array
+    {
+        return ExchangeRate::with(['fromCurrency', 'toCurrency'])
+            ->orderByDesc('date')
+            ->get()
+            ->unique(fn (ExchangeRate $r): string => $r->from_currency_id.'-'.$r->to_currency_id)
+            ->map(fn (ExchangeRate $r): array => [
+                'from' => $r->fromCurrency?->code,
+                'to' => $r->toCurrency?->code,
+                'rate' => (float) $r->rate,
+                'date' => $r->date?->toDateString(),
+            ])
+            ->values()
+            ->all();
+    }
+
     public function getExchangeRate(Currency $fromCurrency, Currency $toCurrency): float|int|null
     {
         $exchangeRate = ExchangeRate::where('from_currency_id', $fromCurrency->id)

--- a/database/migrations/2024_01_18_000001_create_exchange_rates_table.php
+++ b/database/migrations/2024_01_18_000001_create_exchange_rates_table.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // The ExchangeRate model existed without a backing table — this adds it.
+        if (Schema::hasTable('exchange_rates')) {
+            return;
+        }
+
+        Schema::create('exchange_rates', function (Blueprint $table): void {
+            $table->id('exchange_rate_id');
+            $table->unsignedBigInteger('from_currency_id');
+            $table->unsignedBigInteger('to_currency_id');
+            $table->decimal('rate', 20, 10);
+            $table->date('date');
+            $table->timestamps();
+
+            $table->unique(['from_currency_id', 'to_currency_id', 'date']);
+            $table->index('date');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('exchange_rates');
+    }
+};

--- a/tests/Feature/ExchangeRateServiceTest.php
+++ b/tests/Feature/ExchangeRateServiceTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Currency;
+use App\Models\ExchangeRate;
+use App\Models\User;
+use App\Services\ExchangeRateService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ExchangeRateServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function currencies(): array
+    {
+        $usd = Currency::create(['code' => 'USD', 'name' => 'US Dollar', 'symbol' => '$', 'is_default' => true]);
+        $eur = Currency::create(['code' => 'EUR', 'name' => 'Euro', 'symbol' => '€', 'is_default' => false]);
+
+        return [$usd, $eur];
+    }
+
+    public function test_get_latest_rates_returns_one_row_per_pair(): void
+    {
+        [$usd, $eur] = $this->currencies();
+
+        ExchangeRate::create(['from_currency_id' => $usd->currency_id, 'to_currency_id' => $eur->currency_id, 'rate' => 0.90, 'date' => '2026-06-01']);
+        ExchangeRate::create(['from_currency_id' => $usd->currency_id, 'to_currency_id' => $eur->currency_id, 'rate' => 0.92, 'date' => '2026-06-10']);
+
+        $rates = app(ExchangeRateService::class)->getLatestRates();
+
+        $this->assertCount(1, $rates);
+        $this->assertSame('USD', $rates[0]['from']);
+        $this->assertSame('EUR', $rates[0]['to']);
+        $this->assertEquals(0.92, $rates[0]['rate']); // latest by date
+    }
+
+    public function test_exchange_rates_endpoint_returns_ok(): void
+    {
+        [$usd, $eur] = $this->currencies();
+        ExchangeRate::create(['from_currency_id' => $usd->currency_id, 'to_currency_id' => $eur->currency_id, 'rate' => 0.92, 'date' => '2026-06-10']);
+
+        $this->actingAs(User::factory()->create())
+            ->getJson('/api/exchange-rates')
+            ->assertOk()
+            ->assertJsonFragment(['from' => 'USD', 'to' => 'EUR']);
+    }
+}


### PR DESCRIPTION
## Fix: broken `/exchange-rates` endpoint + missing table

Two live bugs surfaced during the Phase 2 recon (flagged in PRD R10):

1. **`ExchangeRate` model had no backing table.** Added the `exchange_rates` migration matching the model's columns (`exchange_rate_id`, `from_currency_id`, `to_currency_id`, `rate`, `date`) with a unique `(from, to, date)` constraint. Any code touching `ExchangeRate` (incl. `ExchangeRateService::updateExchangeRates`/`getExchangeRate`) was relying on a table that didn't exist.

2. **`/api/exchange-rates` 500'd.** The route called `ExchangeRateService::getLatestRates()`, which didn't exist. Implemented it — returns the most recent rate per currency pair with currency codes.

### Tests
- `ExchangeRateServiceTest` (2): service returns one row per pair (newest by date); endpoint returns **200** with the expected JSON.
- Full suite: **254 passing**.
