### PR TITLE
fix(currency): use currency_id PK in ExchangeRateService (R10a)

### DIFF
--- a/app/Services/ExchangeRateService.php
+++ b/app/Services/ExchangeRateService.php
@@ -38,8 +38,8 @@ class ExchangeRateService
 
                 ExchangeRate::updateOrCreate(
                     [
-                        'from_currency_id' => $defaultCurrency->id,
-                        'to_currency_id' => $currency->id,
+                        'from_currency_id' => $defaultCurrency->currency_id,
+                        'to_currency_id' => $currency->currency_id,
                         'date' => now()->toDateString(),
                     ],
                     ['rate' => $rate]
@@ -71,15 +71,15 @@ class ExchangeRateService
 
     public function getExchangeRate(Currency $fromCurrency, Currency $toCurrency): float|int|null
     {
-        $exchangeRate = ExchangeRate::where('from_currency_id', $fromCurrency->id)
-            ->where('to_currency_id', $toCurrency->id)
+        $exchangeRate = ExchangeRate::where('from_currency_id', $fromCurrency->currency_id)
+            ->where('to_currency_id', $toCurrency->currency_id)
             ->latest('date')
             ->first();
 
         if (! $exchangeRate) {
             $this->updateExchangeRates();
-            $exchangeRate = ExchangeRate::where('from_currency_id', $fromCurrency->id)
-                ->where('to_currency_id', $toCurrency->id)
+            $exchangeRate = ExchangeRate::where('from_currency_id', $fromCurrency->currency_id)
+                ->where('to_currency_id', $toCurrency->currency_id)
                 ->latest('date')
                 ->first();
         }

--- a/database/factories/ExchangeRateFactory.php
+++ b/database/factories/ExchangeRateFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\Currency;
+use App\Models\ExchangeRate;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<ExchangeRate>
+ */
+class ExchangeRateFactory extends Factory
+{
+    protected $model = ExchangeRate::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'from_currency_id' => Currency::factory(),
+            'to_currency_id' => Currency::factory(),
+            'rate' => $this->faker->randomFloat(6, 0.5, 2.0),
+            'date' => now()->toDateString(),
+        ];
+    }
+}

--- a/tests/Feature/ExchangeRateUpdateTest.php
+++ b/tests/Feature/ExchangeRateUpdateTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Currency;
+use App\Models\ExchangeRate;
+use App\Services\ExchangeRateService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class ExchangeRateUpdateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function currencies(): array
+    {
+        return [
+            Currency::create(['code' => 'USD', 'name' => 'US Dollar', 'symbol' => '$', 'is_default' => true]),
+            Currency::create(['code' => 'EUR', 'name' => 'Euro', 'symbol' => '€', 'is_default' => false]),
+        ];
+    }
+
+    public function test_update_exchange_rates_persists_correct_currency_ids(): void
+    {
+        config()->set('services.exchange_rate_api', ['key' => 'test', 'url' => 'https://fx.test/latest']);
+        [$usd, $eur] = $this->currencies();
+
+        Http::fake(['fx.test/*' => Http::response(['data' => ['EUR' => 0.92]], 200)]);
+
+        app(ExchangeRateService::class)->updateExchangeRates();
+
+        $this->assertDatabaseHas('exchange_rates', [
+            'from_currency_id' => $usd->currency_id,
+            'to_currency_id' => $eur->currency_id,
+            'rate' => 0.92,
+        ]);
+    }
+
+    public function test_get_exchange_rate_returns_stored_rate(): void
+    {
+        [$usd, $eur] = $this->currencies();
+        ExchangeRate::create([
+            'from_currency_id' => $usd->currency_id,
+            'to_currency_id' => $eur->currency_id,
+            'rate' => 0.92,
+            'date' => '2026-06-10',
+        ]);
+
+        $this->assertEquals(0.92, app(ExchangeRateService::class)->getExchangeRate($usd, $eur));
+    }
+}


### PR DESCRIPTION
## R10a — Currency PK bug in ExchangeRateService

`Currency`'s primary key is `currency_id`, but `ExchangeRateService` read `$currency->id` (always `null`). Worse than the PRD flagged — it broke **both** methods:

- **`updateExchangeRates`** persisted `exchange_rates` rows with `null` `from/to_currency_id`.
- **`getExchangeRate`** matched on `null` ids → **always returned null**, silently breaking `Account::getBalanceInCurrency()` and the GL reporting that depends on it.

### Fix
All four sites switched to `currency_id`. Added `ExchangeRateFactory`.

### Tests
- `ExchangeRateUpdateTest` (2): `updateExchangeRates` persists the correct currency ids (`Http::fake`d API); `getExchangeRate` returns the stored rate.
- Full suite: **256 passing**.

First P1 item of Phase 2 (`TASKS.md` R10a). Depends on #798 (merged).
