### PR TITLE
feat(ui): brand both Filament panels (R14)

### DIFF
--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -37,12 +37,14 @@ class AdminPanelProvider extends PanelProvider
         $panel
             ->id('admin')
             ->path('admin')
+            ->brandName('Liberu Accounting')
             ->login([AuthenticatedSessionController::class, 'create'])
             ->passwordReset()
             ->emailVerification()
             ->viteTheme('resources/css/filament/admin/theme.css')
             ->colors([
-                'primary' => Color::Gray,
+                'primary' => Color::Indigo,
+                'gray' => Color::Slate,
             ])
             ->discoverResources(in: app_path('Filament/Admin/Resources'), for: 'App\\Filament\\Admin\\Resources')
             ->discoverPages(in: app_path('Filament/Admin/Pages'), for: 'App\\Filament\\Admin\\Pages')

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -42,13 +42,15 @@ class AppPanelProvider extends PanelProvider
             ->default()
             ->id('app')
             ->path('app')
+            ->brandName('Liberu Accounting')
             ->login([AuthenticatedSessionController::class, 'create'])
             ->registration()
             ->passwordReset()
             ->emailVerification()
             ->viteTheme('resources/css/filament/admin/theme.css')
             ->colors([
-                'primary' => Color::Gray,
+                'primary' => Color::Indigo,
+                'gray' => Color::Slate,
             ])
             ->userMenuItems([
                 MenuItem::make()

--- a/tests/Feature/PanelBrandingTest.php
+++ b/tests/Feature/PanelBrandingTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use Filament\Facades\Filament;
+use Tests\TestCase;
+
+class PanelBrandingTest extends TestCase
+{
+    public function test_admin_panel_is_branded(): void
+    {
+        $this->assertSame('Liberu Accounting', Filament::getPanel('admin')->getBrandName());
+    }
+
+    public function test_app_panel_is_branded(): void
+    {
+        $this->assertSame('Liberu Accounting', Filament::getPanel('app')->getBrandName());
+    }
+}


### PR DESCRIPTION
## R14 — Brand both Filament panels

Replaces the default unbranded Filament Gray with Liberu branding (Phase 2 P1 quick win).

### Changes
- `->brandName('Liberu Accounting')` on both the admin and app panel providers.
- Primary palette **Indigo** + gray ramp **Slate** (was `Color::Gray`).

### Tests
- `PanelBrandingTest` (2): both panels report the brand name.
- Full suite: **256 passing**.

### Boundary (per `TASKS.md` R14)
Brand name + palette only. Logo asset, dark-mode polish pass, and any bespoke components are left to a design pass — Filament layout is kept as-is.
