### PR TITLE
feat(currency): FX gain/loss posting + reporting currency (R10b)

### DIFF
--- a/app/Models/Account.php
+++ b/app/Models/Account.php
@@ -94,14 +94,17 @@ class Account extends Model
 
     public function getBalanceInCurrency(Currency $targetCurrency)
     {
-        if ($this->currency_id === $targetCurrency->currency_id) {
+        // An account with no explicit currency holds its balance in the default
+        // (reporting) currency — fall back to it rather than passing null.
+        $source = $this->currency ?? Currency::where('is_default', true)->first();
+
+        if (! $source || $source->currency_id === $targetCurrency->currency_id) {
             return $this->balance;
         }
 
-        $exchangeRateService = app(ExchangeRateService::class);
-        $rate = $exchangeRateService->getExchangeRate($this->currency, $targetCurrency);
+        $rate = app(ExchangeRateService::class)->getExchangeRate($source, $targetCurrency);
 
-        return $this->balance * $rate;
+        return $this->balance * ($rate ?? 1);
     }
 
     public function getBalanceInDefaultCurrency()

--- a/app/Services/FxRevaluationService.php
+++ b/app/Services/FxRevaluationService.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\Account;
+use App\Models\JournalEntry;
+
+/**
+ * Posts foreign-exchange gain/loss to the ledger when a foreign-currency
+ * balance is settled at a rate different from the one it was booked at.
+ */
+class FxRevaluationService
+{
+    /**
+     * Reporting-currency gain (+) or loss (−) on settling a foreign amount.
+     */
+    public function gainLoss(float $foreignAmount, float $bookedRate, float $settledRate): float
+    {
+        return round($foreignAmount * ($settledRate - $bookedRate), 2);
+    }
+
+    /**
+     * Post a balanced FX gain/loss entry. Returns null when there is no difference.
+     *
+     * Gain → debit the counter account (more value realised), credit FX gain (income).
+     * Loss → debit FX loss (expense), credit the counter account.
+     */
+    public function postSettlement(
+        float $foreignAmount,
+        float $bookedRate,
+        float $settledRate,
+        Account $counter,
+        Account $fxGain,
+        Account $fxLoss,
+    ): ?JournalEntry {
+        $diff = $this->gainLoss($foreignAmount, $bookedRate, $settledRate);
+
+        if (abs($diff) < 0.005) {
+            return null;
+        }
+
+        $amount = abs($diff);
+        $entry = JournalEntry::create([
+            'entry_date' => now(),
+            'entry_type' => 'general',
+            'memo' => 'FX revaluation on settlement',
+        ]);
+
+        if ($diff > 0) {
+            $entry->lines()->create(['account_id' => $counter->id, 'debit_amount' => $amount, 'credit_amount' => 0, 'description' => 'FX gain on settlement']);
+            $entry->lines()->create(['account_id' => $fxGain->id, 'debit_amount' => 0, 'credit_amount' => $amount, 'description' => 'Foreign exchange gain']);
+        } else {
+            $entry->lines()->create(['account_id' => $fxLoss->id, 'debit_amount' => $amount, 'credit_amount' => 0, 'description' => 'Foreign exchange loss']);
+            $entry->lines()->create(['account_id' => $counter->id, 'debit_amount' => 0, 'credit_amount' => $amount, 'description' => 'FX loss on settlement']);
+        }
+
+        return $entry;
+    }
+}

--- a/app/Services/GeneralLedgerService.php
+++ b/app/Services/GeneralLedgerService.php
@@ -36,6 +36,24 @@ class GeneralLedgerService
             });
     }
 
+    /**
+     * The configured reporting currency (config accounting.reporting_currency,
+     * by ISO code), or the default currency when unset.
+     */
+    public function reportingCurrency(): ?Currency
+    {
+        $code = config('accounting.reporting_currency');
+
+        if ($code) {
+            $currency = Currency::where('code', $code)->first();
+            if ($currency) {
+                return $currency;
+            }
+        }
+
+        return Currency::where('is_default', true)->first();
+    }
+
     public function getTrialBalance($date, ?Currency $displayCurrency = null)
     {
         if (! $displayCurrency instanceof Currency) {

--- a/config/accounting.php
+++ b/config/accounting.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Reporting currency
+    |--------------------------------------------------------------------------
+    | ISO code of the currency financial statements are presented in. When null,
+    | the Currency flagged is_default is used. GeneralLedgerService resolves this.
+    */
+    'reporting_currency' => env('ACCOUNTING_REPORTING_CURRENCY'),
+];

--- a/database/migrations/2026_06_28_000050_add_currency_id_to_accounts.php
+++ b/database/migrations/2026_06_28_000050_add_currency_id_to_accounts.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // Account::getBalanceInCurrency() reads $account->currency, but the column
+        // was never created (it's in the model's fillable only). Add it; null = the
+        // reporting/default currency.
+        if (! Schema::hasColumn('accounts', 'currency_id')) {
+            Schema::table('accounts', function (Blueprint $table): void {
+                $table->unsignedBigInteger('currency_id')->nullable()->index();
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasColumn('accounts', 'currency_id')) {
+            Schema::table('accounts', function (Blueprint $table): void {
+                $table->dropColumn('currency_id');
+            });
+        }
+    }
+};

--- a/tests/Feature/FxRevaluationTest.php
+++ b/tests/Feature/FxRevaluationTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Account;
+use App\Models\User;
+use App\Services\FxRevaluationService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class FxRevaluationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function service(): FxRevaluationService
+    {
+        return app(FxRevaluationService::class);
+    }
+
+    public function test_gain_loss_calculation(): void
+    {
+        // 1000 units, booked at 1.20, settled at 1.25 → +50 gain
+        $this->assertSame(50.0, $this->service()->gainLoss(1000, 1.20, 1.25));
+        // settled lower → loss
+        $this->assertSame(-50.0, $this->service()->gainLoss(1000, 1.25, 1.20));
+    }
+
+    public function test_gain_posts_balanced_entry(): void
+    {
+        $this->actingAs(User::factory()->create());
+        [$counter, $gain, $loss] = $this->accounts();
+
+        $entry = $this->service()->postSettlement(1000, 1.20, 1.25, $counter, $gain, $loss);
+
+        $this->assertTrue($entry->isBalanced());
+        $this->assertEquals(50.0, $entry->total_debits);
+        $this->assertEquals(50.0, $entry->lines()->where('account_id', $counter->id)->sum('debit_amount'));
+        $this->assertEquals(50.0, $entry->lines()->where('account_id', $gain->id)->sum('credit_amount'));
+    }
+
+    public function test_loss_posts_balanced_entry(): void
+    {
+        $this->actingAs(User::factory()->create());
+        [$counter, $gain, $loss] = $this->accounts();
+
+        $entry = $this->service()->postSettlement(1000, 1.25, 1.20, $counter, $gain, $loss);
+
+        $this->assertTrue($entry->isBalanced());
+        $this->assertEquals(50.0, $entry->lines()->where('account_id', $loss->id)->sum('debit_amount'));
+        $this->assertEquals(50.0, $entry->lines()->where('account_id', $counter->id)->sum('credit_amount'));
+    }
+
+    public function test_no_difference_posts_nothing(): void
+    {
+        $this->actingAs(User::factory()->create());
+        [$counter, $gain, $loss] = $this->accounts();
+
+        $this->assertNull($this->service()->postSettlement(1000, 1.20, 1.20, $counter, $gain, $loss));
+    }
+
+    private function accounts(): array
+    {
+        return [
+            Account::factory()->create(['account_type' => 'asset', 'normal_balance' => 'debit']),
+            Account::factory()->create(['account_type' => 'revenue', 'normal_balance' => 'credit']),
+            Account::factory()->create(['account_type' => 'expense', 'normal_balance' => 'debit']),
+        ];
+    }
+}

--- a/tests/Feature/ReportingCurrencyTest.php
+++ b/tests/Feature/ReportingCurrencyTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Account;
+use App\Models\Currency;
+use App\Models\ExchangeRate;
+use App\Services\GeneralLedgerService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ReportingCurrencyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_trial_balance_renders_in_reporting_currency(): void
+    {
+        $usd = Currency::create(['code' => 'USD', 'name' => 'US Dollar', 'symbol' => '$', 'is_default' => true]);
+        $eur = Currency::create(['code' => 'EUR', 'name' => 'Euro', 'symbol' => '€', 'is_default' => false]);
+        ExchangeRate::create(['from_currency_id' => $usd->currency_id, 'to_currency_id' => $eur->currency_id, 'rate' => 0.90, 'date' => now()->toDateString()]);
+
+        // Account holds 1000 in the default currency (no explicit currency = default).
+        Account::factory()->create(['account_type' => 'asset', 'normal_balance' => 'debit', 'balance' => 1000]);
+
+        $rows = app(GeneralLedgerService::class)->getTrialBalance(now(), $eur);
+
+        $row = $rows->first();
+        $this->assertSame('EUR', $row['currency']);
+        $this->assertEqualsWithDelta(900.0, $row['debit'], 0.01); // 1000 USD × 0.90
+    }
+}


### PR DESCRIPTION
## R10b — Multi-currency: FX gain/loss + reporting currency

Completes multi-currency beyond the rate data (R10a fixed the rates).

### What's included
- **`FxRevaluationService`**
  - `gainLoss()` — reporting-currency gain (+) / loss (−) on settling a foreign amount at a changed rate.
  - `postSettlement()` — posts a **balanced** journal entry: gain → debit counter / credit FX gain; loss → debit FX loss / credit counter; no-op when the rate is unchanged.
- **Reporting currency** — `config/accounting.php` + `GeneralLedgerService::reportingCurrency()` (by ISO code, falls back to the default currency). Trial balance already accepts a display currency and now renders correctly in it.

### Bug fixed
`Account::getBalanceInCurrency` dereferenced a null `$this->currency` — **accounts had no `currency_id` column at all** — so it threw for any non-default reporting currency (broke `getTrialBalance` in a reporting currency). Added the `accounts.currency_id` column + a null-safe fallback to the default currency.

### Tests
- `FxRevaluationTest` (4): gain/loss calc, balanced gain entry, balanced loss entry, no-op.
- `ReportingCurrencyTest` (1): trial balance renders 1000 USD as **900 EUR** at 0.90.
- Full suite: **269 passing**.

### Boundary (`TASKS.md` R10b)
Per-transaction currency capture already exists on the `Transaction` model; exposing it in the UI/API is a follow-up. Uses the existing rate source — no live-FX trading.
