### PR TITLE
feat(xero): two-way invoice sync via OAuth 2.0 (R11)

### DIFF
--- a/app/Http/Controllers/Api/XeroController.php
+++ b/app/Http/Controllers/Api/XeroController.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\XeroConnection;
+use App\Services\XeroService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+
+class XeroController extends Controller
+{
+    public function __construct(private readonly XeroService $xero) {}
+
+    public function connect(): JsonResponse
+    {
+        return response()->json([
+            'authorization_url' => $this->xero->getAuthorizationUrl(Str::random(40)),
+        ]);
+    }
+
+    public function callback(Request $request): JsonResponse
+    {
+        $validated = $request->validate(['code' => ['required', 'string']]);
+
+        $connection = $this->xero->handleCallback((int) $request->user()->id, $validated['code']);
+
+        return response()->json(['success' => true, 'tenant_id' => $connection->tenant_id]);
+    }
+
+    public function sync(Request $request, XeroConnection $connection): JsonResponse
+    {
+        abort_unless($connection->user_id === $request->user()->id, 403);
+
+        return response()->json(['success' => true, 'invoices_synced' => $this->xero->pullInvoices($connection)]);
+    }
+}

--- a/app/Models/XeroConnection.php
+++ b/app/Models/XeroConnection.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Traits\IsTenantModel;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class XeroConnection extends Model
+{
+    use HasFactory;
+    use IsTenantModel;
+
+    protected $fillable = [
+        'user_id',
+        'team_id',
+        'tenant_id',
+        'access_token',
+        'refresh_token',
+        'token_expires_at',
+        'last_synced_at',
+        'status',
+    ];
+
+    protected $casts = [
+        'access_token' => 'encrypted',
+        'refresh_token' => 'encrypted',
+        'token_expires_at' => 'datetime',
+        'last_synced_at' => 'datetime',
+    ];
+
+    protected $hidden = [
+        'access_token',
+        'refresh_token',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Services/XeroService.php
+++ b/app/Services/XeroService.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\Customer;
+use App\Models\Invoice;
+use App\Models\XeroConnection;
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
+
+/**
+ * Two-way sync with Xero via OAuth 2.0. Mirrors QuickBooksService — kept as a
+ * separate service rather than a shared base; extract a common contract if a
+ * third accounting provider lands.
+ */
+class XeroService
+{
+    /** @var array<string, mixed> */
+    private array $cfg;
+
+    public function __construct()
+    {
+        $this->cfg = config('services.xero');
+    }
+
+    public function getAuthorizationUrl(string $state): string
+    {
+        return $this->cfg['authorization_url'].'?'.http_build_query([
+            'response_type' => 'code',
+            'client_id' => $this->cfg['client_id'],
+            'redirect_uri' => $this->cfg['redirect_uri'],
+            'scope' => 'offline_access accounting.transactions accounting.contacts',
+            'state' => $state,
+        ]);
+    }
+
+    /**
+     * Exchange the code for tokens, resolve the Xero tenant, persist the connection.
+     */
+    public function handleCallback(int $userId, string $code): XeroConnection
+    {
+        $tokens = Http::asForm()
+            ->withBasicAuth($this->cfg['client_id'], $this->cfg['client_secret'])
+            ->post($this->cfg['token_url'], [
+                'grant_type' => 'authorization_code',
+                'code' => $code,
+                'redirect_uri' => $this->cfg['redirect_uri'],
+            ])->throw()->json();
+
+        $tenantId = Http::withToken($tokens['access_token'])
+            ->acceptJson()
+            ->get($this->cfg['connections_url'])
+            ->throw()
+            ->json()[0]['tenantId'] ?? null;
+
+        return XeroConnection::updateOrCreate(
+            ['user_id' => $userId, 'tenant_id' => $tenantId],
+            [
+                'access_token' => $tokens['access_token'],
+                'refresh_token' => $tokens['refresh_token'],
+                'token_expires_at' => now()->addSeconds((int) ($tokens['expires_in'] ?? 1800)),
+                'status' => 'active',
+            ],
+        );
+    }
+
+    public function pushInvoice(Invoice $invoice, XeroConnection $connection): Invoice
+    {
+        $payload = ['Invoices' => [[
+            'Type' => 'ACCREC',
+            'Contact' => ['Name' => $invoice->customer?->customer_name ?? ('Customer '.$invoice->customer_id)],
+            'LineItems' => [[
+                'Description' => 'Invoice '.($invoice->invoice_number ?? $invoice->id),
+                'Quantity' => 1,
+                'UnitAmount' => (float) $invoice->total_amount,
+                'AccountCode' => '200',
+            ]],
+            'Status' => 'AUTHORISED',
+        ]]];
+
+        $body = $this->client($connection)->post('/Invoices', $payload)->throw()->json();
+
+        $invoice->update(['xero_id' => $body['Invoices'][0]['InvoiceID'] ?? $invoice->xero_id]);
+
+        return $invoice;
+    }
+
+    public function pullInvoices(XeroConnection $connection): int
+    {
+        $rows = $this->client($connection)->get('/Invoices')->throw()->json()['Invoices'] ?? [];
+
+        foreach ($rows as $row) {
+            Invoice::updateOrCreate(
+                ['xero_id' => $row['InvoiceID']],
+                [
+                    'invoice_number' => $row['InvoiceNumber'] ?? ('XERO-'.$row['InvoiceID']),
+                    'customer_id' => $this->resolveCustomerId($row['Contact'] ?? null),
+                    'total_amount' => $row['Total'] ?? 0,
+                    'invoice_date' => $row['Date'] ?? now()->toDateString(),
+                    'payment_status' => 'pending',
+                ],
+            );
+        }
+
+        $connection->update(['last_synced_at' => now()]);
+
+        return count($rows);
+    }
+
+    private function client(XeroConnection $connection): PendingRequest
+    {
+        return Http::withToken($connection->access_token)
+            ->withHeaders(['Xero-tenant-id' => $connection->tenant_id])
+            ->acceptJson()
+            ->baseUrl($this->cfg['api_base_url']);
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $contact
+     */
+    private function resolveCustomerId(?array $contact): int
+    {
+        $name = $contact['Name'] ?? 'Xero Customer';
+        $ref = Str::random(8);
+
+        $customer = Customer::firstOrCreate(
+            ['customer_name' => $name],
+            [
+                'customer_last_name' => '',
+                'customer_address' => 'Imported from Xero',
+                'customer_email' => Str::slug($name).'.'.$ref.'@xero.imported',
+                'customer_phone' => 'xero-'.$ref,
+                'customer_city' => 'Unknown',
+            ],
+        );
+
+        return (int) $customer->getKey();
+    }
+}

--- a/config/services.php
+++ b/config/services.php
@@ -33,6 +33,16 @@ return [
         'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
     ],
 
+    'xero' => [
+        'client_id' => env('XERO_CLIENT_ID'),
+        'client_secret' => env('XERO_CLIENT_SECRET'),
+        'redirect_uri' => env('XERO_REDIRECT_URI'),
+        'authorization_url' => env('XERO_AUTHORIZATION_URL', 'https://login.xero.com/identity/connect/authorize'),
+        'token_url' => env('XERO_TOKEN_URL', 'https://identity.xero.com/connect/token'),
+        'connections_url' => env('XERO_CONNECTIONS_URL', 'https://api.xero.com/connections'),
+        'api_base_url' => env('XERO_API_BASE_URL', 'https://api.xero.com/api.xro/2.0'),
+    ],
+
     'qbo' => [
         'client_id' => env('QBO_CLIENT_ID'),
         'client_secret' => env('QBO_CLIENT_SECRET'),

--- a/database/migrations/2026_06_28_000060_create_xero_connections_table.php
+++ b/database/migrations/2026_06_28_000060_create_xero_connections_table.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('xero_connections', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->unsignedBigInteger('team_id')->nullable();
+            $table->string('tenant_id');
+            $table->text('access_token')->nullable();
+            $table->text('refresh_token')->nullable();
+            $table->timestamp('token_expires_at')->nullable();
+            $table->timestamp('last_synced_at')->nullable();
+            $table->string('status')->default('active');
+            $table->timestamps();
+
+            $table->unique(['user_id', 'tenant_id']);
+        });
+
+        Schema::table('invoices', function (Blueprint $table): void {
+            if (! Schema::hasColumn('invoices', 'xero_id')) {
+                $table->string('xero_id')->nullable()->index();
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('xero_connections');
+        Schema::table('invoices', function (Blueprint $table): void {
+            $table->dropColumn('xero_id');
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -16,6 +16,7 @@ use App\Http\Controllers\Api\RevolutWebhookController;
 use App\Http\Controllers\Api\TransactionController;
 use App\Http\Controllers\Api\WiseController;
 use App\Http\Controllers\Api\WiseWebhookController;
+use App\Http\Controllers\Api\XeroController;
 use App\Services\ExchangeRateService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
@@ -94,6 +95,13 @@ Route::middleware('auth:sanctum')->group(function (): void {
         Route::post('/connections/{connection}/pay', [RevolutController::class, 'sendPayment'])->middleware('throttle:30,1');
         Route::post('/connections/{connection}/bulk-pay', [RevolutController::class, 'sendBulkPayment'])->middleware('throttle:10,1');
         Route::delete('/connections/{connection}', [RevolutController::class, 'removeConnection']);
+    });
+
+    // Xero API Routes
+    Route::prefix('xero')->middleware('throttle:60,1')->group(function (): void {
+        Route::get('/connect', [XeroController::class, 'connect']);
+        Route::get('/callback', [XeroController::class, 'callback']);
+        Route::post('/connections/{connection}/sync', [XeroController::class, 'sync'])->middleware('throttle:10,1');
     });
 
     // QuickBooks Online API Routes

--- a/tests/Feature/Api/XeroSyncTest.php
+++ b/tests/Feature/Api/XeroSyncTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Models\Customer;
+use App\Models\Invoice;
+use App\Models\User;
+use App\Models\XeroConnection;
+use App\Services\XeroService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class XeroSyncTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+
+        config()->set('services.xero', [
+            'client_id' => 'test_client',
+            'client_secret' => 'test_secret',
+            'redirect_uri' => 'https://app.test/api/xero/callback',
+            'authorization_url' => 'https://login.xero.com/identity/connect/authorize',
+            'token_url' => 'https://identity.xero.com/connect/token',
+            'connections_url' => 'https://api.xero.com/connections',
+            'api_base_url' => 'https://api.xero.com/api.xro/2.0',
+        ]);
+    }
+
+    private function connection(): XeroConnection
+    {
+        return XeroConnection::create([
+            'user_id' => $this->user->id,
+            'tenant_id' => 'tenant-123',
+            'access_token' => 'access-token',
+            'refresh_token' => 'refresh-token',
+            'token_expires_at' => now()->addHour(),
+            'status' => 'active',
+        ]);
+    }
+
+    private function service(): XeroService
+    {
+        return app(XeroService::class);
+    }
+
+    public function test_connect_returns_authorization_url(): void
+    {
+        $response = $this->actingAs($this->user)->getJson('/api/xero/connect');
+
+        $response->assertOk()->assertJsonStructure(['authorization_url']);
+        $this->assertStringContainsString('login.xero.com/identity/connect/authorize', $response->json('authorization_url'));
+        $this->assertStringContainsString('client_id=test_client', $response->json('authorization_url'));
+    }
+
+    public function test_callback_exchanges_code_and_stores_connection(): void
+    {
+        Http::fake([
+            'identity.xero.com/connect/token' => Http::response(['access_token' => 'at', 'refresh_token' => 'rt', 'expires_in' => 1800], 200),
+            'api.xero.com/connections' => Http::response([['tenantId' => 'tenant-xyz']], 200),
+        ]);
+
+        $response = $this->actingAs($this->user)->getJson('/api/xero/callback?code=authcode');
+
+        $response->assertOk();
+        $this->assertDatabaseHas('xero_connections', ['user_id' => $this->user->id, 'tenant_id' => 'tenant-xyz', 'status' => 'active']);
+    }
+
+    public function test_push_invoice_stores_remote_id(): void
+    {
+        Http::fake(['*/api.xro/2.0/Invoices*' => Http::response(['Invoices' => [['InvoiceID' => 'xero-guid-1']]], 200)]);
+
+        $customer = Customer::factory()->create();
+        $invoice = Invoice::factory()->create(['customer_id' => $customer->id, 'total_amount' => 150]);
+
+        $this->service()->pushInvoice($invoice, $this->connection());
+
+        $this->assertSame('xero-guid-1', $invoice->fresh()->xero_id);
+        Http::assertSent(fn ($r) => str_contains($r->url(), '/api.xro/2.0/Invoices') && $r->method() === 'POST');
+    }
+
+    public function test_pull_invoices_creates_local_invoices(): void
+    {
+        Http::fake(['*/api.xro/2.0/Invoices*' => Http::response([
+            'Invoices' => [[
+                'InvoiceID' => 'xero-guid-9',
+                'InvoiceNumber' => 'INV-X9',
+                'Total' => 320.50,
+                'Date' => '2026-06-01',
+                'Contact' => ['Name' => 'Globex'],
+            ]],
+        ], 200)]);
+
+        $count = $this->service()->pullInvoices($this->connection());
+
+        $this->assertSame(1, $count);
+        $this->assertDatabaseHas('invoices', ['xero_id' => 'xero-guid-9', 'invoice_number' => 'INV-X9']);
+        $this->assertDatabaseHas('customers', ['customer_name' => 'Globex']);
+    }
+}


### PR DESCRIPTION
## R11 — Xero two-way invoice sync

Adds a Xero integration mirroring the QBO one (R11 acceptance: round-trip an invoice both directions).

### Design
Built as a **standalone `XeroService`**, not by refactoring the working/tested `QuickBooksService` into a shared base — that refactor is invasive and risks the QBO suite for little gain at two providers. Extract a common contract if/when a third provider lands (noted).

### What's included
- **OAuth 2.0** — connect + callback (token exchange, then tenant resolution via `GET /connections`), encrypted tokens on `XeroConnection`, `services.xero` config.
- **`XeroService`** — `pushInvoice` (ACCREC) and `pullInvoices` (Xero `Contact` → local `Customer`); adds `invoices.xero_id`.
- **`/api/xero/*`** routes — connect, callback, sync.

### Tests
- `XeroSyncTest` (4): authorization URL, callback stores connection, invoice push stores remote id, pull creates local invoice + customer.
- Full suite: **284 passing**.

### Boundary (`TASKS.md` R11)
Invoice round-trip is the acceptance gate. Accounts/bills/payments mapping + the Sage provider follow the same shape as the QBO build (follow-up).
