### PR TITLE
feat(modules): Inventory feature module (R9 reference)

### DIFF
--- a/app/Filament/App/Resources/InventoryItems/InventoryItemResource.php
+++ b/app/Filament/App/Resources/InventoryItems/InventoryItemResource.php
@@ -9,6 +9,7 @@ use App\Filament\App\Resources\InventoryItems\Pages\EditInventoryItem;
 use App\Filament\App\Resources\InventoryItems\Pages\ListInventoryItems;
 use App\Models\Account;
 use App\Models\InventoryItem;
+use App\Modules\Inventory\InventoryModule;
 use App\Services\InventoryMovementService;
 use Filament\Actions\Action;
 use Filament\Actions\BulkActionGroup;
@@ -30,6 +31,20 @@ class InventoryItemResource extends Resource
 {
     #[\Override]
     protected static ?string $model = InventoryItem::class;
+
+    // Gated by the Inventory module: disabling the module removes this resource
+    // (access + navigation) without touching its code or data.
+    #[\Override]
+    public static function canAccess(): bool
+    {
+        return InventoryModule::isActive();
+    }
+
+    #[\Override]
+    public static function shouldRegisterNavigation(): bool
+    {
+        return InventoryModule::isActive();
+    }
 
     #[\Override]
     protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-cube';

--- a/app/Modules/Inventory/InventoryModule.php
+++ b/app/Modules/Inventory/InventoryModule.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modules\Inventory;
+
+use App\Models\Module;
+use App\Modules\BaseModule;
+
+/**
+ * Inventory feature module — the reference conversion of an existing feature
+ * into the module framework. The inventory models/migrations/services stay in
+ * their current locations (DB table names unchanged); this module wraps them in
+ * the enable/disable lifecycle and gates the Filament resource on its state.
+ */
+class InventoryModule extends BaseModule
+{
+    public const KEY = 'Inventory';
+
+    /**
+     * Whether the inventory feature is active. Reads the module's DB record;
+     * when unmanaged (no record / table absent) it defaults to enabled so the
+     * feature is non-breaking out of the box.
+     */
+    public static function isActive(): bool
+    {
+        try {
+            $record = Module::findByName(self::KEY);
+
+            if ($record !== null) {
+                return (bool) $record->enabled;
+            }
+        } catch (\Throwable) {
+            // modules table not migrated yet — treat as enabled.
+        }
+
+        return true;
+    }
+
+    protected function onEnable(): void
+    {
+        $this->setEnabled(true);
+    }
+
+    protected function onDisable(): void
+    {
+        $this->setEnabled(false);
+    }
+
+    private function setEnabled(bool $enabled): void
+    {
+        Module::updateOrCreate(
+            ['name' => self::KEY],
+            ['enabled' => $enabled, 'version' => $this->getVersion(), 'description' => $this->getDescription()],
+        );
+    }
+}

--- a/app/Modules/Inventory/module.json
+++ b/app/Modules/Inventory/module.json
@@ -1,0 +1,9 @@
+{
+    "name": "Inventory",
+    "version": "1.0.0",
+    "description": "Stock tracking with FIFO/LIFO/average valuation and COGS posting.",
+    "dependencies": [],
+    "config": {
+        "enabled": true
+    }
+}

--- a/tests/Feature/InventoryModuleTest.php
+++ b/tests/Feature/InventoryModuleTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Filament\App\Resources\InventoryItems\InventoryItemResource;
+use App\Models\Module;
+use App\Modules\Inventory\InventoryModule;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class InventoryModuleTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_active_by_default_when_unmanaged(): void
+    {
+        $this->assertTrue(InventoryModule::isActive());
+        $this->assertTrue(InventoryItemResource::canAccess());
+    }
+
+    public function test_disabling_module_removes_resource_access(): void
+    {
+        Module::create(['name' => InventoryModule::KEY, 'enabled' => false]);
+
+        $this->assertFalse(InventoryModule::isActive());
+        $this->assertFalse(InventoryItemResource::canAccess());
+        $this->assertFalse(InventoryItemResource::shouldRegisterNavigation());
+    }
+
+    public function test_enabling_module_restores_resource_access(): void
+    {
+        Module::create(['name' => InventoryModule::KEY, 'enabled' => true]);
+
+        $this->assertTrue(InventoryModule::isActive());
+        $this->assertTrue(InventoryItemResource::canAccess());
+    }
+}


### PR DESCRIPTION
## R9 — Inventory feature module (reference)

Converts **Inventory** into a first-class module using the existing framework (`BaseModule`/`ModuleManager`/`Module` model), as the reference for the others.

### Approach (low-risk, "tables stable")
The inventory models, migrations and services **stay where they are** — no namespace relocation, no table renames. The module is a lifecycle + gating wrapper:
- `app/Modules/Inventory/` — `InventoryModule` (extends `BaseModule`) + `module.json`.
- `InventoryModule::isActive()` reads the `modules` DB record; defaults to **enabled** when unmanaged, so existing installs are unaffected.
- `InventoryItemResource::canAccess()` / `shouldRegisterNavigation()` follow the module state — **disabling the module removes the panel resource** (access + navigation) without touching code or data; enabling restores it.

### Tests
- `InventoryModuleTest` (3): active by default, disabling hides the resource, enabling restores it.
- Full suite: **287 passing**.

### Boundary (`TASKS.md` R9 — do last, one module per PR)
Inventory is the reference. **Fixed Assets** and **Reconciliation** modules follow the same gate-in-place pattern (separate PRs). Physically moving models/migrations into the module directory is deliberately avoided to keep DB table names stable and the diff reviewable.
