### PR TITLE
feat(modules): Fixed Assets feature module (F1)

### DIFF
--- a/app/Filament/App/Resources/AssetAcquisitions/AssetAcquisitionResource.php
+++ b/app/Filament/App/Resources/AssetAcquisitions/AssetAcquisitionResource.php
@@ -8,6 +8,7 @@ use App\Filament\App\Resources\AssetAcquisitions\Pages\CreateAssetAcquisition;
 use App\Filament\App\Resources\AssetAcquisitions\Pages\EditAssetAcquisition;
 use App\Filament\App\Resources\AssetAcquisitions\Pages\ListAssetAcquisitions;
 use App\Models\AssetAcquisition;
+use App\Modules\FixedAssets\FixedAssetsModule;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
@@ -21,6 +22,19 @@ class AssetAcquisitionResource extends Resource
 {
     #[\Override]
     protected static ?string $model = AssetAcquisition::class;
+
+    // Gated by the FixedAssets module: disabling it removes this resource.
+    #[\Override]
+    public static function canAccess(): bool
+    {
+        return FixedAssetsModule::isActive();
+    }
+
+    #[\Override]
+    public static function shouldRegisterNavigation(): bool
+    {
+        return FixedAssetsModule::isActive();
+    }
 
     #[\Override]
     protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-rectangle-stack';

--- a/app/Filament/App/Resources/Assets/AssetResource.php
+++ b/app/Filament/App/Resources/Assets/AssetResource.php
@@ -9,6 +9,7 @@ use App\Filament\App\Resources\Assets\Pages\DepreciationSchedulePage;
 use App\Filament\App\Resources\Assets\Pages\EditAsset;
 use App\Filament\App\Resources\Assets\Pages\ListAssets;
 use App\Models\Asset;
+use App\Modules\FixedAssets\FixedAssetsModule;
 use Filament\Actions\Action;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteBulkAction;
@@ -26,6 +27,19 @@ class AssetResource extends Resource
 {
     #[\Override]
     protected static ?string $model = Asset::class;
+
+    // Gated by the FixedAssets module: disabling it removes this resource.
+    #[\Override]
+    public static function canAccess(): bool
+    {
+        return FixedAssetsModule::isActive();
+    }
+
+    #[\Override]
+    public static function shouldRegisterNavigation(): bool
+    {
+        return FixedAssetsModule::isActive();
+    }
 
     #[\Override]
     protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-cube';

--- a/app/Modules/FixedAssets/FixedAssetsModule.php
+++ b/app/Modules/FixedAssets/FixedAssetsModule.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modules\FixedAssets;
+
+use App\Models\Module;
+use App\Modules\BaseModule;
+
+/**
+ * Fixed Assets feature module. Like InventoryModule, this gates the existing
+ * asset code/resources by enable state without relocating models, migrations
+ * or renaming tables.
+ */
+class FixedAssetsModule extends BaseModule
+{
+    public const KEY = 'FixedAssets';
+
+    /**
+     * Whether the fixed-assets feature is active. Reads the module's DB record;
+     * defaults to enabled when unmanaged so the feature is non-breaking.
+     */
+    public static function isActive(): bool
+    {
+        try {
+            $record = Module::findByName(self::KEY);
+
+            if ($record !== null) {
+                return (bool) $record->enabled;
+            }
+        } catch (\Throwable) {
+            // modules table not migrated yet — treat as enabled.
+        }
+
+        return true;
+    }
+
+    protected function onEnable(): void
+    {
+        $this->setEnabled(true);
+    }
+
+    protected function onDisable(): void
+    {
+        $this->setEnabled(false);
+    }
+
+    private function setEnabled(bool $enabled): void
+    {
+        Module::updateOrCreate(
+            ['name' => self::KEY],
+            ['enabled' => $enabled, 'version' => $this->getVersion(), 'description' => $this->getDescription()],
+        );
+    }
+}

--- a/app/Modules/FixedAssets/module.json
+++ b/app/Modules/FixedAssets/module.json
@@ -1,0 +1,9 @@
+{
+    "name": "FixedAssets",
+    "version": "1.0.0",
+    "description": "Asset register with straight-line and reducing-balance depreciation.",
+    "dependencies": [],
+    "config": {
+        "enabled": true
+    }
+}

--- a/tests/Feature/FixedAssetsModuleTest.php
+++ b/tests/Feature/FixedAssetsModuleTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Filament\App\Resources\AssetAcquisitions\AssetAcquisitionResource;
+use App\Filament\App\Resources\Assets\AssetResource;
+use App\Models\Module;
+use App\Modules\FixedAssets\FixedAssetsModule;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class FixedAssetsModuleTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_active_by_default_when_unmanaged(): void
+    {
+        $this->assertTrue(FixedAssetsModule::isActive());
+        $this->assertTrue(AssetResource::canAccess());
+        $this->assertTrue(AssetAcquisitionResource::canAccess());
+    }
+
+    public function test_disabling_module_removes_resource_access(): void
+    {
+        Module::create(['name' => FixedAssetsModule::KEY, 'enabled' => false]);
+
+        $this->assertFalse(FixedAssetsModule::isActive());
+        $this->assertFalse(AssetResource::canAccess());
+        $this->assertFalse(AssetResource::shouldRegisterNavigation());
+        $this->assertFalse(AssetAcquisitionResource::canAccess());
+    }
+
+    public function test_enabling_module_restores_resource_access(): void
+    {
+        Module::create(['name' => FixedAssetsModule::KEY, 'enabled' => true]);
+
+        $this->assertTrue(FixedAssetsModule::isActive());
+        $this->assertTrue(AssetResource::canAccess());
+    }
+}


### PR DESCRIPTION
## F1 — Fixed Assets feature module

Second module conversion, same **gate-in-place** pattern as Inventory (R9, #806). Phase 3 P1.

### What's included
- `app/Modules/FixedAssets/` — `FixedAssetsModule` (extends `BaseModule`) + `module.json`.
- `FixedAssetsModule::isActive()` reads the `modules` DB record; defaults to **enabled** when unmanaged (non-breaking).
- **`AssetResource`** and **`AssetAcquisitionResource`** gated via `canAccess()` / `shouldRegisterNavigation()` — disabling the module removes both asset panel resources (access + navigation) without touching code or data.

### Tests
- `FixedAssetsModuleTest` (3): active by default, disabling hides both resources, enabling restores.
- Full suite: **290 passing**.

### Boundary
Gate-in-place — no model/migration relocation, table names unchanged. Reconciliation module (F2) is the next conversion, same pattern.
