### PR TITLE
feat(modules): Reconciliation feature module (F2)

### DIFF
--- a/app/Filament/App/Resources/BankStatements/BankStatementResource.php
+++ b/app/Filament/App/Resources/BankStatements/BankStatementResource.php
@@ -8,6 +8,7 @@ use App\Filament\App\Resources\BankStatements\Pages\CreateBankStatement;
 use App\Filament\App\Resources\BankStatements\Pages\EditBankStatement;
 use App\Filament\App\Resources\BankStatements\Pages\ListBankStatements;
 use App\Models\BankStatement;
+use App\Modules\Reconciliation\ReconciliationModule;
 use App\Services\BankStatementImportService;
 use App\Services\ReconciliationService;
 use Exception;
@@ -229,7 +230,7 @@ class BankStatementResource extends Resource
                     ->label('Reconcile')
                     ->icon('heroicon-o-check-circle')
                     ->color('success')
-                    ->visible(fn (BankStatement $record): bool => $record->transactions()->exists() && ! $record->reconciled)
+                    ->visible(fn (BankStatement $record): bool => ReconciliationModule::isActive() && $record->transactions()->exists() && ! $record->reconciled)
                     ->requiresConfirmation()
                     ->modalHeading('Reconcile Bank Statement')
                     ->modalDescription('This will attempt to match and reconcile all transactions for this statement.')
@@ -265,7 +266,7 @@ class BankStatementResource extends Resource
                     ->label('View Discrepancies')
                     ->icon('heroicon-o-exclamation-triangle')
                     ->color('warning')
-                    ->visible(fn (BankStatement $record) => $record->transactions()->exists())
+                    ->visible(fn (BankStatement $record) => ReconciliationModule::isActive() && $record->transactions()->exists())
                     ->modalHeading('Reconciliation Discrepancies')
                     ->modalContent(function (BankStatement $record): Factory|View {
                         $reconciliationService = app(ReconciliationService::class);

--- a/app/Modules/Reconciliation/ReconciliationModule.php
+++ b/app/Modules/Reconciliation/ReconciliationModule.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modules\Reconciliation;
+
+use App\Models\Module;
+use App\Modules\BaseModule;
+
+/**
+ * Reconciliation feature module. Gates the bank-statement reconcile workflow
+ * (reconcile + discrepancies actions) by enable state, without relocating the
+ * ReconciliationService or the BankStatement resource. Bank statements remain
+ * available; only the reconciliation actions are gated.
+ */
+class ReconciliationModule extends BaseModule
+{
+    public const KEY = 'Reconciliation';
+
+    /**
+     * Whether the reconciliation feature is active. Reads the module's DB
+     * record; defaults to enabled when unmanaged so it's non-breaking.
+     */
+    public static function isActive(): bool
+    {
+        try {
+            $record = Module::findByName(self::KEY);
+
+            if ($record !== null) {
+                return (bool) $record->enabled;
+            }
+        } catch (\Throwable) {
+            // modules table not migrated yet — treat as enabled.
+        }
+
+        return true;
+    }
+
+    protected function onEnable(): void
+    {
+        $this->setEnabled(true);
+    }
+
+    protected function onDisable(): void
+    {
+        $this->setEnabled(false);
+    }
+
+    private function setEnabled(bool $enabled): void
+    {
+        Module::updateOrCreate(
+            ['name' => self::KEY],
+            ['enabled' => $enabled, 'version' => $this->getVersion(), 'description' => $this->getDescription()],
+        );
+    }
+}

--- a/app/Modules/Reconciliation/module.json
+++ b/app/Modules/Reconciliation/module.json
@@ -1,0 +1,9 @@
+{
+    "name": "Reconciliation",
+    "version": "1.0.0",
+    "description": "Bank statement reconciliation: transaction matching and discrepancy workflow.",
+    "dependencies": [],
+    "config": {
+        "enabled": true
+    }
+}

--- a/tests/Feature/ReconciliationModuleTest.php
+++ b/tests/Feature/ReconciliationModuleTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Module;
+use App\Modules\Reconciliation\ReconciliationModule;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ReconciliationModuleTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_active_by_default_when_unmanaged(): void
+    {
+        $this->assertTrue(ReconciliationModule::isActive());
+    }
+
+    public function test_disabling_module_gates_reconcile_workflow(): void
+    {
+        Module::create(['name' => ReconciliationModule::KEY, 'enabled' => false]);
+
+        $this->assertFalse(ReconciliationModule::isActive());
+    }
+
+    public function test_enabling_module_restores_reconcile_workflow(): void
+    {
+        Module::create(['name' => ReconciliationModule::KEY, 'enabled' => true]);
+
+        $this->assertTrue(ReconciliationModule::isActive());
+    }
+}


### PR DESCRIPTION
## F2 — Reconciliation feature module

Third module conversion (Phase 3 P1). Reconciliation is a **feature of bank statements**, not a standalone resource — so this gates the reconcile *workflow* (the `reconcile` + `view_discrepancies` actions), leaving bank statements themselves available.

### What's included
- `app/Modules/Reconciliation/` — `ReconciliationModule` (extends `BaseModule`) + `module.json`.
- `ReconciliationModule::isActive()` reads the `modules` DB record; defaults to **enabled** when unmanaged (non-breaking).
- Both reconcile actions' `->visible()` closures now AND in `isActive()` — disabling the module hides the reconcile flow without touching `ReconciliationService` or the statement resource.

### Tests
- `ReconciliationModuleTest` (3): active by default, disable gates the workflow, enable restores.
- Full suite: **293 passing**.

### Boundary
Gate-in-place; no relocation. Completes the Phase 3 P1 module conversions (Inventory #806, Fixed Assets #808, Reconciliation here).
