### PR TITLE
feat(payroll): pay-period apportionment + tax-year selector (F7)

### DIFF
--- a/app/Services/PayrollTaxService.php
+++ b/app/Services/PayrollTaxService.php
@@ -6,20 +6,47 @@ namespace App\Services;
 
 /**
  * UK statutory payroll tax calculator: PAYE income tax, employee + employer
- * National Insurance, and student-loan repayment. All inputs/outputs are
- * ANNUAL. Figures come from config/payroll.php (2024/25 by default).
+ * National Insurance, and student-loan repayment. Annual methods are the core;
+ * computeForPeriod() apportions to a pay period. Figures come from
+ * config/payroll.php, keyed by tax year (default 2024/25); forYear() selects one.
  *
- * ponytail: annual basis — pay-period (monthly/weekly) apportionment and
- * cumulative tax-code operation are a follow-up; the band/threshold maths is
- * the part that has to be right.
+ * ponytail: period apportionment is even-pay / non-cumulative (W1/M1) basis.
+ * True cumulative (year-to-date recalculation from pay history) needs a payslip
+ * ledger — a follow-up; isCumulative() already classifies the code.
  */
 class PayrollTaxService
 {
+    /** Periods per year for each pay frequency. */
+    public const PERIODS = ['weekly' => 52, 'fortnightly' => 26, 'monthly' => 12];
+
+    private string $taxYear;
+
+    public function __construct(?string $taxYear = null)
+    {
+        $this->taxYear = $taxYear ?? (string) config('payroll.default_tax_year');
+    }
+
+    /**
+     * A calculator bound to a specific tax year (e.g. '2025-26').
+     */
+    public function forYear(string $taxYear): self
+    {
+        return new self($taxYear);
+    }
+
+    /**
+     * Read a value from the selected tax year's tables.
+     */
+    private function cfg(string $path): mixed
+    {
+        return config("payroll.tax_years.{$this->taxYear}.{$path}");
+    }
+
     public function incomeTax(float $annualGross, string $taxCode = '1257L'): float
     {
         $allowance = $this->allowanceFromCode($taxCode);
 
-        $taper = (float) config('payroll.paye.allowance_taper_threshold');
+        $taper = (float) $this->cfg('paye.allowance_taper_threshold');
         if ($annualGross > $taper) {
             $allowance = max(0.0, $allowance - floor(($annualGross - $taper) / 2));
         }
@@ -28,7 +55,7 @@ class PayrollTaxService
 
         $tax = 0.0;
         $lower = 0.0;
-        foreach (config('payroll.paye.bands') as $band) {
+        foreach ($this->cfg('paye.bands') as $band) {
             $upto = $band['upto'] ?? INF;
             $inBand = max(0.0, min($taxable, $upto) - $lower);
             $tax += $inBand * $band['rate'];
@@ -43,7 +70,7 @@ class PayrollTaxService
 
     public function employeeNi(float $annualGross): float
     {
-        $c = config('payroll.national_insurance.employee');
+        $c = $this->cfg('national_insurance.employee');
 
         $main = max(0.0, min($annualGross, $c['upper_earnings_limit']) - $c['primary_threshold']) * $c['main_rate'];
         $upper = max(0.0, $annualGross - $c['upper_earnings_limit']) * $c['upper_rate'];
@@ -53,7 +80,7 @@ class PayrollTaxService
 
     public function employerNi(float $annualGross): float
     {
-        $c = config('payroll.national_insurance.employer');
+        $c = $this->cfg('national_insurance.employer');
 
         return round(max(0.0, $annualGross - $c['secondary_threshold']) * $c['rate'], 2);
     }
@@ -64,7 +91,7 @@ class PayrollTaxService
             return 0.0;
         }
 
-        $c = config('payroll.student_loan.'.$plan);
+        $c = $this->cfg('student_loan.'.$plan);
         if (! $c) {
             return 0.0;
         }
@@ -91,15 +118,42 @@ class PayrollTaxService
     }
 
     /**
-     * Personal allowance from a tax code: the numeric part × 10 (e.g. 1257L → 12 570).
-     * Falls back to the configured standard allowance for non-numeric codes.
+     * Statutory figures for one pay period (even-pay / non-cumulative basis):
+     * annualise the period gross, compute, then divide each figure by the
+     * number of periods. This is exactly how a W1/M1 (non-cumulative) code runs.
+     *
+     * @param  int|string  $periods  periods-per-year, or a frequency key ('monthly', 'weekly', 'fortnightly')
+     * @return array{income_tax: float, employee_ni: float, employer_ni: float, student_loan: float, net: float}
+     */
+    public function computeForPeriod(float $periodGross, int|string $periods, string $taxCode = '1257L', ?string $studentLoanPlan = null): array
+    {
+        $periodsPerYear = is_string($periods) ? (self::PERIODS[$periods] ?? 12) : $periods;
+
+        $annual = $this->compute($periodGross * $periodsPerYear, $taxCode, $studentLoanPlan);
+
+        return array_map(fn (float $v): float => round($v / $periodsPerYear, 2), $annual);
+    }
+
+    /**
+     * Whether a tax code operates cumulatively. A W1/M1/X suffix means
+     * non-cumulative (each period stands alone); anything else is cumulative.
+     */
+    public function isCumulative(string $taxCode): bool
+    {
+        return preg_match('/\b(W1|M1|X)$/i', trim($taxCode)) !== 1;
+    }
+
+    /**
+     * Personal allowance from a tax code: the leading numeric part × 10
+     * (e.g. 1257L → 12 570, and "1257L W1" → 12 570). Falls back to the
+     * configured standard allowance for codes with no numeric part (BR/D0/NT).
      */
     private function allowanceFromCode(string $taxCode): float
     {
-        if (preg_match('/^(\d+)[A-Za-z]?$/', trim($taxCode), $m) === 1) {
+        if (preg_match('/^(\d+)/', trim($taxCode), $m) === 1) {
             return (float) $m[1] * 10;
         }
 
-        return (float) config('payroll.paye.personal_allowance');
+        return (float) $this->cfg('paye.personal_allowance');
     }
 }

--- a/config/payroll.php
+++ b/config/payroll.php
@@ -6,47 +6,44 @@ declare(strict_types=1);
 |--------------------------------------------------------------------------
 | Payroll tax tables (UK)
 |--------------------------------------------------------------------------
-| Annual statutory figures used by PayrollTaxService. Defaults are the
-| 2024/25 tax year — update per tax year. All thresholds/amounts are annual.
+| Annual statutory figures used by PayrollTaxService, keyed by tax year so
+| multiple years coexist. All thresholds/amounts are annual. PayrollTaxService
+| selects 'default_tax_year' unless asked for a specific year via forYear().
 */
 
 return [
-    'tax_year' => '2024-25',
+    'default_tax_year' => '2024-25',
 
-    'paye' => [
-        // Standard personal allowance (tax code 1257L → 12 570). Income-tax bands
-        // are amounts of TAXABLE income (after allowance).
-        'personal_allowance' => 12570,
-        // Allowance is withdrawn £1 for every £2 of income above this.
-        'allowance_taper_threshold' => 100000,
-        // Cumulative bands of TAXABLE income (after the allowance):
-        'bands' => [
-            ['rate' => 0.20, 'upto' => 37700],    // basic
-            ['rate' => 0.40, 'upto' => 112570],   // higher (125 140 gross − 12 570 allowance)
-            ['rate' => 0.45, 'upto' => null],     // additional
+    'tax_years' => [
+        '2024-25' => [
+            'paye' => [
+                'personal_allowance' => 12570,
+                'allowance_taper_threshold' => 100000,
+                // Cumulative bands of TAXABLE income (after the allowance):
+                'bands' => [
+                    ['rate' => 0.20, 'upto' => 37700],    // basic
+                    ['rate' => 0.40, 'upto' => 112570],   // higher (125 140 gross − 12 570 allowance)
+                    ['rate' => 0.45, 'upto' => null],     // additional
+                ],
+            ],
+            'national_insurance' => [
+                'employee' => [
+                    'primary_threshold' => 12570,
+                    'upper_earnings_limit' => 50270,
+                    'main_rate' => 0.08,
+                    'upper_rate' => 0.02,
+                ],
+                'employer' => [
+                    'secondary_threshold' => 9100,
+                    'rate' => 0.138,
+                ],
+            ],
+            'student_loan' => [
+                'plan_1' => ['threshold' => 24990, 'rate' => 0.09],
+                'plan_2' => ['threshold' => 27295, 'rate' => 0.09],
+                'plan_4' => ['threshold' => 31395, 'rate' => 0.09],
+                'postgraduate' => ['threshold' => 21000, 'rate' => 0.06],
+            ],
         ],
-    ],
-
-    'national_insurance' => [
-        // Employee Class 1 (Category A): 8% between PT and UEL, 2% above UEL.
-        'employee' => [
-            'primary_threshold' => 12570,
-            'upper_earnings_limit' => 50270,
-            'main_rate' => 0.08,
-            'upper_rate' => 0.02,
-        ],
-        // Employer: 13.8% above the secondary threshold.
-        'employer' => [
-            'secondary_threshold' => 9100,
-            'rate' => 0.138,
-        ],
-    ],
-
-    'student_loan' => [
-        // plan => [threshold, rate]
-        'plan_1' => ['threshold' => 24990, 'rate' => 0.09],
-        'plan_2' => ['threshold' => 27295, 'rate' => 0.09],
-        'plan_4' => ['threshold' => 31395, 'rate' => 0.09],
-        'postgraduate' => ['threshold' => 21000, 'rate' => 0.06],
     ],
 ];

--- a/tests/Feature/PayrollTaxPeriodTest.php
+++ b/tests/Feature/PayrollTaxPeriodTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Services\PayrollTaxService;
+use Tests\TestCase;
+
+class PayrollTaxPeriodTest extends TestCase
+{
+    private function tax(): PayrollTaxService
+    {
+        return app(PayrollTaxService::class);
+    }
+
+    public function test_monthly_apportionment(): void
+    {
+        // £2,500/month → £30,000/yr. Annual PAYE 3,486 / EE NI 1,394.40.
+        $r = $this->tax()->computeForPeriod(2500, 'monthly');
+
+        $this->assertSame(290.50, $r['income_tax']);   // 3,486 / 12
+        $this->assertSame(116.20, $r['employee_ni']);  // 1,394.40 / 12
+        $this->assertSame(2093.30, $r['net']);         // 25,119.60 / 12
+    }
+
+    public function test_weekly_apportionment_uses_52_periods(): void
+    {
+        $r = $this->tax()->computeForPeriod(1000, 'weekly');           // £52,000/yr
+        $annual = $this->tax()->compute(52000);
+
+        $this->assertSame(round($annual['income_tax'] / 52, 2), $r['income_tax']);
+    }
+
+    public function test_w1m1_code_parses_like_cumulative_for_allowance(): void
+    {
+        $this->assertSame($this->tax()->incomeTax(30000, '1257L'), $this->tax()->incomeTax(30000, '1257L W1'));
+        $this->assertFalse($this->tax()->isCumulative('1257L W1'));
+        $this->assertTrue($this->tax()->isCumulative('1257L'));
+    }
+
+    public function test_for_year_selects_the_right_tables(): void
+    {
+        // A fabricated year with a lower basic rate (10%) → less tax.
+        config()->set('payroll.tax_years.2099-00', config('payroll.tax_years.2024-25'));
+        config()->set('payroll.tax_years.2099-00.paye.bands', [
+            ['rate' => 0.10, 'upto' => 37700],
+            ['rate' => 0.40, 'upto' => 112570],
+            ['rate' => 0.45, 'upto' => null],
+        ]);
+
+        $base = $this->tax()->incomeTax(30000);                 // default 2024-25, taxable 17,430 @ 20%
+        $future = $this->tax()->forYear('2099-00')->incomeTax(30000); // @ 10%
+
+        $this->assertSame(3486.00, $base);
+        $this->assertSame(1743.00, $future); // 17,430 × 10%
+    }
+}


### PR DESCRIPTION
## F7 — Pay-period payroll apportionment + tax-year selector

Extends the PAYE/NI engine (R12, #802) beyond annual-only. Phase 3 P2.

### What's included
- **Year-keyed config** — `config/payroll.php` restructured to `tax_years` map + `default_tax_year`. 2024-25 figures are unchanged, so all existing results hold.
- **`PayrollTaxService::forYear($year)`** — returns a calculator bound to a tax year; an internal `cfg()` reads that year's tables.
- **`computeForPeriod($periodGross, 'monthly'|'weekly'|'fortnightly'|N, ...)`** — annualises the period gross, computes, and divides each figure per period (even-pay / non-cumulative basis).
- **`isCumulative($code)`** — classifies `W1`/`M1`/`X` suffix codes as non-cumulative; allowance parsing now tolerates suffixes (`"1257L W1"` → 12,570).

### Tests
- `PayrollTaxPeriodTest` (4): monthly apportionment (£2,500/mo → PAYE £290.50, EE NI £116.20, net £2,093.30), weekly (52 periods), W1/M1 parsing + classification, tax-year switch picks the right tables.
- R12 `PayrollTaxServiceTest` unchanged (config restructure is transparent).
- Full suite: **297 passing**.

### Boundary (`TASKS.md` F7)
UK only. **True cumulative** (year-to-date recalculation from pay history) needs a payslip ledger — noted as a follow-up; `computeForPeriod` is the correct non-cumulative / W1M1 behavior. No pensions/auto-enrolment.
