### PR TITLE
feat(currency): per-transaction currency in API + FX settlement (F5)

### DIFF
--- a/app/Http/Controllers/Api/TransactionController.php
+++ b/app/Http/Controllers/Api/TransactionController.php
@@ -34,6 +34,8 @@ class TransactionController extends Controller
             'amount' => 'required|numeric',
             'transaction_date' => 'required|date',
             'description' => 'required|string',
+            'currency_id' => 'sometimes|nullable|exists:currencies,currency_id',
+            'exchange_rate' => 'sometimes|nullable|numeric',
         ]);
 
         $validated['user_id'] = auth()->id();
@@ -52,6 +54,8 @@ class TransactionController extends Controller
             'amount' => 'sometimes|numeric',
             'transaction_date' => 'sometimes|date',
             'description' => 'sometimes|string',
+            'currency_id' => 'sometimes|nullable|exists:currencies,currency_id',
+            'exchange_rate' => 'sometimes|nullable|numeric',
         ]);
 
         $transaction->update($validated);

--- a/app/Services/TransactionSettlementService.php
+++ b/app/Services/TransactionSettlementService.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\Account;
+use App\Models\JournalEntry;
+use App\Models\Transaction;
+
+/**
+ * Settles a foreign-currency transaction at a (possibly changed) rate and posts
+ * the resulting FX gain/loss to the ledger via FxRevaluationService.
+ */
+class TransactionSettlementService
+{
+    public function __construct(private readonly FxRevaluationService $fx) {}
+
+    /**
+     * Post the FX gain/loss between the transaction's booked rate and the
+     * settlement rate, on its foreign amount. Returns null when there is no
+     * difference (or the transaction was already in the reporting currency).
+     */
+    public function settle(Transaction $transaction, float $settledRate, Account $counter, Account $fxGain, Account $fxLoss): ?JournalEntry
+    {
+        $bookedRate = (float) ($transaction->exchange_rate ?? 1.0);
+        $foreignAmount = (float) $transaction->amount;
+
+        return $this->fx->postSettlement($foreignAmount, $bookedRate, $settledRate, $counter, $fxGain, $fxLoss);
+    }
+}

--- a/tests/Feature/Api/TransactionCurrencyTest.php
+++ b/tests/Feature/Api/TransactionCurrencyTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Models\Account;
+use App\Models\Currency;
+use App\Models\Transaction;
+use App\Models\User;
+use App\Services\TransactionSettlementService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TransactionCurrencyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_api_captures_transaction_currency_and_rate(): void
+    {
+        $user = User::factory()->create();
+        $account = Account::factory()->create(['user_id' => $user->id]);
+        $eur = Currency::create(['code' => 'EUR', 'name' => 'Euro', 'symbol' => '€', 'is_default' => false]);
+
+        $response = $this->actingAs($user)->postJson('/api/transactions', [
+            'account_id' => $account->id,
+            'amount' => 1000,
+            'transaction_date' => '2026-06-01',
+            'description' => 'Foreign sale',
+            'currency_id' => $eur->currency_id,
+            'exchange_rate' => 1.20,
+        ]);
+
+        $response->assertCreated();
+        $this->assertDatabaseHas('transactions', [
+            'account_id' => $account->id,
+            'currency_id' => $eur->currency_id,
+            'exchange_rate' => 1.20,
+        ]);
+    }
+
+    public function test_settlement_posts_fx_gain(): void
+    {
+        $this->actingAs(User::factory()->create());
+
+        $eur = Currency::create(['code' => 'EUR', 'name' => 'Euro', 'symbol' => '€', 'is_default' => false]);
+        $cash = Account::factory()->create(['account_type' => 'asset', 'normal_balance' => 'debit']);
+        $fxGain = Account::factory()->create(['account_type' => 'revenue', 'normal_balance' => 'credit']);
+        $fxLoss = Account::factory()->create(['account_type' => 'expense', 'normal_balance' => 'debit']);
+
+        // 1000 EUR booked at 1.20.
+        $tx = Transaction::create([
+            'account_id' => $cash->id,
+            'amount' => 1000,
+            'transaction_date' => '2026-06-01',
+            'description' => 'Foreign invoice',
+            'currency_id' => $eur->currency_id,
+            'exchange_rate' => 1.20,
+        ]);
+
+        // Settled at 1.25 → +50 FX gain.
+        $entry = app(TransactionSettlementService::class)->settle($tx, 1.25, $cash, $fxGain, $fxLoss);
+
+        $this->assertTrue($entry->isBalanced());
+        $this->assertEquals(50.0, $entry->total_debits);
+        $this->assertEquals(50.0, $entry->lines()->where('account_id', $fxGain->id)->sum('credit_amount'));
+    }
+}


### PR DESCRIPTION
## F5 — Per-transaction currency (API) + FX settlement

Exposes the `Transaction` model's existing currency support and ties it to R10b's FX gain/loss posting. Phase 3 P2.

### What's included
- **API**: `TransactionController` store/update now accept `currency_id` + `exchange_rate` (validated against `currencies.currency_id`).
- **UI**: the Filament transaction form **already had** the currency + exchange-rate fields — no change needed there.
- **`TransactionSettlementService::settle()`**: posts the FX gain/loss between a transaction's booked rate and the settlement rate, on its foreign amount, via `FxRevaluationService` (R10b).

### Tests
- `TransactionCurrencyTest` (2): API captures `currency_id`/`exchange_rate`; settling a 1000 EUR transaction booked at 1.20 at 1.25 posts a **balanced +50 FX gain** entry.
- Full suite: **299 passing**.

### Boundary (`TASKS.md` F5)
Uses the existing rate source. Completes Phase 3 P2 (with F7 #810).
