### PR TITLE
feat(xero): account, bill and payment sync (F3)

### DIFF
--- a/app/Services/XeroService.php
+++ b/app/Services/XeroService.php
@@ -4,8 +4,12 @@ declare(strict_types=1);
 
 namespace App\Services;
 
+use App\Models\Account;
+use App\Models\Bill;
 use App\Models\Customer;
 use App\Models\Invoice;
+use App\Models\Payment;
+use App\Models\Vendor;
 use App\Models\XeroConnection;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Facades\Http;
@@ -108,6 +112,159 @@ class XeroService
         $connection->update(['last_synced_at' => now()]);
 
         return count($rows);
+    }
+
+    /** local account_type → Xero [Type, Class]. */
+    private const XERO_ACCOUNT = [
+        'asset' => ['CURRENT', 'ASSET'],
+        'liability' => ['CURRLIAB', 'LIABILITY'],
+        'equity' => ['EQUITY', 'EQUITY'],
+        'revenue' => ['REVENUE', 'REVENUE'],
+        'income' => ['REVENUE', 'REVENUE'],
+        'expense' => ['EXPENSE', 'EXPENSE'],
+    ];
+
+    /** Xero Account Class → local account_type. */
+    private const XERO_CLASS = [
+        'ASSET' => 'asset',
+        'LIABILITY' => 'liability',
+        'EQUITY' => 'equity',
+        'REVENUE' => 'revenue',
+        'EXPENSE' => 'expense',
+    ];
+
+    public function pushAccount(Account $account, XeroConnection $connection): Account
+    {
+        [$type] = self::XERO_ACCOUNT[$account->account_type] ?? ['CURRENT', 'ASSET'];
+
+        $body = $this->client($connection)->post('/Accounts', ['Accounts' => [[
+            'Code' => (string) $account->account_number,
+            'Name' => $account->account_name,
+            'Type' => $type,
+        ]]])->throw()->json();
+
+        $account->update(['xero_id' => $body['Accounts'][0]['AccountID'] ?? $account->xero_id]);
+
+        return $account;
+    }
+
+    public function pullAccounts(XeroConnection $connection): int
+    {
+        $rows = $this->client($connection)->get('/Accounts')->throw()->json()['Accounts'] ?? [];
+
+        foreach ($rows as $row) {
+            Account::updateOrCreate(
+                ['xero_id' => $row['AccountID']],
+                [
+                    'account_name' => $row['Name'] ?? ('Xero Account '.$row['AccountID']),
+                    'account_type' => self::XERO_CLASS[$row['Class'] ?? ''] ?? 'asset',
+                    'account_number' => isset($row['Code']) && is_numeric($row['Code'])
+                        ? (int) $row['Code']
+                        : 9000 + crc32((string) $row['AccountID']) % 1000,
+                ],
+            );
+        }
+
+        $connection->update(['last_synced_at' => now()]);
+
+        return count($rows);
+    }
+
+    public function pushBill(Bill $bill, XeroConnection $connection): Bill
+    {
+        $body = $this->client($connection)->post('/Invoices', ['Invoices' => [[
+            'Type' => 'ACCPAY',
+            'Contact' => ['Name' => $bill->vendor?->name ?? ('Vendor '.$bill->vendor_id)],
+            'LineItems' => [[
+                'Description' => 'Bill '.($bill->bill_number ?? $bill->getKey()),
+                'Quantity' => 1,
+                'UnitAmount' => (float) $bill->total_amount,
+                'AccountCode' => '400',
+            ]],
+            'Status' => 'AUTHORISED',
+        ]]])->throw()->json();
+
+        $bill->update(['xero_id' => $body['Invoices'][0]['InvoiceID'] ?? $bill->xero_id]);
+
+        return $bill;
+    }
+
+    public function pullBills(XeroConnection $connection): int
+    {
+        $rows = $this->client($connection)
+            ->get('/Invoices', ['where' => 'Type=="ACCPAY"'])
+            ->throw()
+            ->json()['Invoices'] ?? [];
+
+        foreach ($rows as $row) {
+            Bill::updateOrCreate(
+                ['xero_id' => $row['InvoiceID']],
+                [
+                    'vendor_id' => $this->resolveVendorId($row['Contact'] ?? null),
+                    'total_amount' => $row['Total'] ?? 0,
+                    'bill_date' => $row['Date'] ?? now()->toDateString(),
+                    'due_date' => $row['DueDate'] ?? ($row['Date'] ?? now()->toDateString()),
+                ],
+            );
+        }
+
+        $connection->update(['last_synced_at' => now()]);
+
+        return count($rows);
+    }
+
+    public function pushPayment(Payment $payment, XeroConnection $connection): Payment
+    {
+        $invoice = Invoice::find($payment->invoice_id);
+
+        $body = $this->client($connection)->post('/Payments', ['Payments' => [[
+            'Invoice' => ['InvoiceID' => $invoice?->xero_id],
+            'Account' => ['Code' => '090'],
+            'Amount' => (float) $payment->payment_amount,
+            'Date' => optional($payment->payment_date)->format('Y-m-d') ?? (string) $payment->payment_date,
+        ]]])->throw()->json();
+
+        $payment->update(['xero_id' => $body['Payments'][0]['PaymentID'] ?? $payment->xero_id]);
+
+        return $payment;
+    }
+
+    public function pullPayments(XeroConnection $connection): int
+    {
+        $rows = $this->client($connection)->get('/Payments')->throw()->json()['Payments'] ?? [];
+
+        foreach ($rows as $row) {
+            $invoiceId = (int) (Invoice::where('xero_id', $row['Invoice']['InvoiceID'] ?? null)->value('id') ?? 0);
+
+            Payment::updateOrCreate(
+                ['xero_id' => $row['PaymentID']],
+                [
+                    'invoice_id' => $invoiceId,
+                    'payment_amount' => $row['Amount'] ?? 0,
+                    'payment_date' => $row['Date'] ?? now()->toDateString(),
+                ],
+            );
+        }
+
+        $connection->update(['last_synced_at' => now()]);
+
+        return count($rows);
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $contact
+     */
+    private function resolveVendorId(?array $contact): int
+    {
+        $name = $contact['Name'] ?? 'Xero Vendor';
+        $ref = Str::random(8);
+
+        $vendor = Vendor::firstOrCreate(
+            ['name' => $name],
+            ['email' => Str::slug($name).'.'.$ref.'@xero.imported'],
+        );
+
+        return (int) $vendor->getKey();
     }
 
     private function client(XeroConnection $connection): PendingRequest

--- a/database/migrations/2026_06_28_000070_add_xero_id_to_synced_tables.php
+++ b/database/migrations/2026_06_28_000070_add_xero_id_to_synced_tables.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /** @var list<string> */
+    private array $tables = ['accounts', 'bills', 'payments'];
+
+    public function up(): void
+    {
+        foreach ($this->tables as $table) {
+            if (Schema::hasTable($table) && ! Schema::hasColumn($table, 'xero_id')) {
+                Schema::table($table, function (Blueprint $t): void {
+                    $t->string('xero_id')->nullable()->index();
+                });
+            }
+        }
+    }
+
+    public function down(): void
+    {
+        foreach ($this->tables as $table) {
+            if (Schema::hasColumn($table, 'xero_id')) {
+                Schema::table($table, function (Blueprint $t): void {
+                    $t->dropColumn('xero_id');
+                });
+            }
+        }
+    }
+};

--- a/tests/Feature/Api/XeroEntitiesSyncTest.php
+++ b/tests/Feature/Api/XeroEntitiesSyncTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Models\Account;
+use App\Models\Bill;
+use App\Models\Invoice;
+use App\Models\Payment;
+use App\Models\User;
+use App\Models\Vendor;
+use App\Models\XeroConnection;
+use App\Services\XeroService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class XeroEntitiesSyncTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config()->set('services.xero', [
+            'client_id' => 'c', 'client_secret' => 's', 'redirect_uri' => 'https://app.test/cb',
+            'authorization_url' => 'https://login.xero.com/identity/connect/authorize',
+            'token_url' => 'https://identity.xero.com/connect/token',
+            'connections_url' => 'https://api.xero.com/connections',
+            'api_base_url' => 'https://api.xero.com/api.xro/2.0',
+        ]);
+    }
+
+    private function connection(): XeroConnection
+    {
+        return XeroConnection::create([
+            'user_id' => User::factory()->create()->id,
+            'tenant_id' => 'tenant-123',
+            'access_token' => 'at',
+            'refresh_token' => 'rt',
+            'token_expires_at' => now()->addHour(),
+            'status' => 'active',
+        ]);
+    }
+
+    private function service(): XeroService
+    {
+        return app(XeroService::class);
+    }
+
+    public function test_push_account(): void
+    {
+        Http::fake(['*/api.xro/2.0/Accounts*' => Http::response(['Accounts' => [['AccountID' => 'xa-1']]], 200)]);
+        $account = Account::factory()->create(['account_type' => 'revenue']);
+
+        $this->service()->pushAccount($account, $this->connection());
+
+        $this->assertSame('xa-1', $account->fresh()->xero_id);
+    }
+
+    public function test_pull_accounts(): void
+    {
+        Http::fake(['*/api.xro/2.0/Accounts*' => Http::response(['Accounts' => [
+            ['AccountID' => 'xa-9', 'Code' => '4200', 'Name' => 'Sales', 'Class' => 'REVENUE'],
+        ]], 200)]);
+
+        $this->assertSame(1, $this->service()->pullAccounts($this->connection()));
+        $this->assertDatabaseHas('accounts', ['xero_id' => 'xa-9', 'account_type' => 'revenue']);
+    }
+
+    public function test_push_bill(): void
+    {
+        Http::fake(['*/api.xro/2.0/Invoices*' => Http::response(['Invoices' => [['InvoiceID' => 'xb-1']]], 200)]);
+        $bill = Bill::factory()->create(['vendor_id' => Vendor::factory()->create()->vendor_id, 'total_amount' => 480]);
+
+        $this->service()->pushBill($bill, $this->connection());
+
+        $this->assertSame('xb-1', $bill->fresh()->xero_id);
+    }
+
+    public function test_pull_bills(): void
+    {
+        Http::fake(['*/api.xro/2.0/Invoices*' => Http::response(['Invoices' => [
+            ['InvoiceID' => 'xb-9', 'Total' => 250, 'Date' => '2026-06-01', 'Contact' => ['Name' => 'Acme Supplies']],
+        ]], 200)]);
+
+        $this->assertSame(1, $this->service()->pullBills($this->connection()));
+        $this->assertDatabaseHas('bills', ['xero_id' => 'xb-9']);
+        $this->assertDatabaseHas('vendors', ['name' => 'Acme Supplies']);
+    }
+
+    public function test_push_payment(): void
+    {
+        Http::fake(['*/api.xro/2.0/Payments*' => Http::response(['Payments' => [['PaymentID' => 'xp-1']]], 200)]);
+        $invoice = Invoice::factory()->create(['xero_id' => 'xinv-1']);
+        $payment = Payment::create(['invoice_id' => $invoice->id, 'payment_amount' => 150, 'payment_date' => '2026-06-10']);
+
+        $this->service()->pushPayment($payment, $this->connection());
+
+        $this->assertSame('xp-1', $payment->fresh()->xero_id);
+    }
+
+    public function test_pull_payments(): void
+    {
+        $invoice = Invoice::factory()->create(['xero_id' => '500']);
+        Http::fake(['*/api.xro/2.0/Payments*' => Http::response(['Payments' => [
+            ['PaymentID' => 'xp-9', 'Amount' => 150, 'Date' => '2026-06-10', 'Invoice' => ['InvoiceID' => '500']],
+        ]], 200)]);
+
+        $this->assertSame(1, $this->service()->pullPayments($this->connection()));
+        $this->assertDatabaseHas('payments', ['xero_id' => 'xp-9', 'invoice_id' => $invoice->id]);
+    }
+}


### PR DESCRIPTION
## F3 — Xero account / bill / payment sync

Brings Xero to entity parity with QBO (R11, #805, did invoices only). Phase 3 P3.

### What's included
- **`pushAccount` / `pullAccounts`** — maps local `account_type` ⇄ Xero `Type`/`Class`; pulled accounts get a generated number when Xero `Code` is non-numeric.
- **`pushBill` / `pullBills`** — Xero **ACCPAY** invoices; `Contact` resolved to (or created as) a local `Vendor` on pull.
- **`pushPayment` / `pullPayments`** — links via Xero `Invoice.InvoiceID`; resolves back to the local invoice by `xero_id`.
- Adds `xero_id` to `accounts` / `bills` / `payments` (guarded migration).

### Tests
- `XeroEntitiesSyncTest` (6): push + pull for accounts, bills, payments.
- Full suite: **303 passing**.

### Boundary
Xero only. With QBO + Xero now both at full entity coverage, F4 (Sage) is the point to extract a shared provider-sync contract.
