### PR TITLE
feat(sage): two-way invoice sync via OAuth 2.0 (F4)

### DIFF
--- a/app/Http/Controllers/Api/SageController.php
+++ b/app/Http/Controllers/Api/SageController.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\SageConnection;
+use App\Services\SageService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+
+class SageController extends Controller
+{
+    public function __construct(private readonly SageService $sage) {}
+
+    public function connect(): JsonResponse
+    {
+        return response()->json([
+            'authorization_url' => $this->sage->getAuthorizationUrl(Str::random(40)),
+        ]);
+    }
+
+    public function callback(Request $request): JsonResponse
+    {
+        $validated = $request->validate(['code' => ['required', 'string']]);
+
+        $connection = $this->sage->handleCallback((int) $request->user()->id, $validated['code']);
+
+        return response()->json(['success' => true, 'business_id' => $connection->business_id]);
+    }
+
+    public function sync(Request $request, SageConnection $connection): JsonResponse
+    {
+        abort_unless($connection->user_id === $request->user()->id, 403);
+
+        return response()->json(['success' => true, 'invoices_synced' => $this->sage->pullInvoices($connection)]);
+    }
+}

--- a/app/Models/SageConnection.php
+++ b/app/Models/SageConnection.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Traits\IsTenantModel;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class SageConnection extends Model
+{
+    use HasFactory;
+    use IsTenantModel;
+
+    protected $fillable = [
+        'user_id',
+        'team_id',
+        'business_id',
+        'access_token',
+        'refresh_token',
+        'token_expires_at',
+        'last_synced_at',
+        'status',
+    ];
+
+    protected $casts = [
+        'access_token' => 'encrypted',
+        'refresh_token' => 'encrypted',
+        'token_expires_at' => 'datetime',
+        'last_synced_at' => 'datetime',
+    ];
+
+    protected $hidden = [
+        'access_token',
+        'refresh_token',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Services/SageService.php
+++ b/app/Services/SageService.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\Customer;
+use App\Models\Invoice;
+use App\Models\SageConnection;
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
+
+/**
+ * Two-way sync with Sage Accounting via OAuth 2.0. Mirrors QuickBooksService /
+ * XeroService. With three providers now sharing this shape, a common sync
+ * contract is the natural next refactor (kept out of this PR to avoid touching
+ * the two working integrations).
+ */
+class SageService
+{
+    /** @var array<string, mixed> */
+    private array $cfg;
+
+    public function __construct()
+    {
+        $this->cfg = config('services.sage');
+    }
+
+    public function getAuthorizationUrl(string $state): string
+    {
+        return $this->cfg['authorization_url'].'?'.http_build_query([
+            'response_type' => 'code',
+            'client_id' => $this->cfg['client_id'],
+            'redirect_uri' => $this->cfg['redirect_uri'],
+            'scope' => 'full_access',
+            'state' => $state,
+        ]);
+    }
+
+    /**
+     * Exchange the code for tokens, resolve the Sage business, persist the connection.
+     */
+    public function handleCallback(int $userId, string $code): SageConnection
+    {
+        $tokens = Http::asForm()
+            ->withBasicAuth($this->cfg['client_id'], $this->cfg['client_secret'])
+            ->post($this->cfg['token_url'], [
+                'grant_type' => 'authorization_code',
+                'code' => $code,
+                'redirect_uri' => $this->cfg['redirect_uri'],
+            ])->throw()->json();
+
+        $businessId = Http::withToken($tokens['access_token'])
+            ->acceptJson()
+            ->get($this->cfg['businesses_url'])
+            ->throw()
+            ->json()['$items'][0]['id'] ?? null;
+
+        return SageConnection::updateOrCreate(
+            ['user_id' => $userId, 'business_id' => $businessId],
+            [
+                'access_token' => $tokens['access_token'],
+                'refresh_token' => $tokens['refresh_token'],
+                'token_expires_at' => now()->addSeconds((int) ($tokens['expires_in'] ?? 3600)),
+                'status' => 'active',
+            ],
+        );
+    }
+
+    public function pushInvoice(Invoice $invoice, SageConnection $connection): Invoice
+    {
+        $payload = ['sales_invoice' => [
+            'contact_id' => (string) ($invoice->customer_id ?? ''),
+            'date' => optional($invoice->invoice_date)->format('Y-m-d') ?? (string) $invoice->invoice_date,
+            'invoice_lines' => [[
+                'description' => 'Invoice '.($invoice->invoice_number ?? $invoice->id),
+                'quantity' => 1,
+                'unit_price' => (float) $invoice->total_amount,
+            ]],
+        ]];
+
+        $body = $this->client($connection)->post('/sales_invoices', $payload)->throw()->json();
+
+        $invoice->update(['sage_id' => $body['id'] ?? $invoice->sage_id]);
+
+        return $invoice;
+    }
+
+    public function pullInvoices(SageConnection $connection): int
+    {
+        $rows = $this->client($connection)->get('/sales_invoices')->throw()->json()['$items'] ?? [];
+
+        foreach ($rows as $row) {
+            Invoice::updateOrCreate(
+                ['sage_id' => $row['id']],
+                [
+                    'invoice_number' => $row['displayed_as'] ?? ('SAGE-'.$row['id']),
+                    'customer_id' => $this->resolveCustomerId($row['contact_name'] ?? null),
+                    'total_amount' => $row['total_amount'] ?? 0,
+                    'invoice_date' => $row['date'] ?? now()->toDateString(),
+                    'payment_status' => 'pending',
+                ],
+            );
+        }
+
+        $connection->update(['last_synced_at' => now()]);
+
+        return count($rows);
+    }
+
+    private function client(SageConnection $connection): PendingRequest
+    {
+        return Http::withToken($connection->access_token)
+            ->acceptJson()
+            ->baseUrl($this->cfg['api_base_url']);
+    }
+
+    private function resolveCustomerId(?string $contactName): int
+    {
+        $name = $contactName ?? 'Sage Customer';
+        $ref = Str::random(8);
+
+        $customer = Customer::firstOrCreate(
+            ['customer_name' => $name],
+            [
+                'customer_last_name' => '',
+                'customer_address' => 'Imported from Sage',
+                'customer_email' => Str::slug($name).'.'.$ref.'@sage.imported',
+                'customer_phone' => 'sage-'.$ref,
+                'customer_city' => 'Unknown',
+            ],
+        );
+
+        return (int) $customer->getKey();
+    }
+}

--- a/config/services.php
+++ b/config/services.php
@@ -33,6 +33,16 @@ return [
         'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
     ],
 
+    'sage' => [
+        'client_id' => env('SAGE_CLIENT_ID'),
+        'client_secret' => env('SAGE_CLIENT_SECRET'),
+        'redirect_uri' => env('SAGE_REDIRECT_URI'),
+        'authorization_url' => env('SAGE_AUTHORIZATION_URL', 'https://www.sageone.com/oauth2/auth/central'),
+        'token_url' => env('SAGE_TOKEN_URL', 'https://oauth.accounting.sage.com/token'),
+        'businesses_url' => env('SAGE_BUSINESSES_URL', 'https://api.accounting.sage.com/v3.1/businesses'),
+        'api_base_url' => env('SAGE_API_BASE_URL', 'https://api.accounting.sage.com/v3.1'),
+    ],
+
     'xero' => [
         'client_id' => env('XERO_CLIENT_ID'),
         'client_secret' => env('XERO_CLIENT_SECRET'),

--- a/database/migrations/2026_06_28_000080_create_sage_connections_table.php
+++ b/database/migrations/2026_06_28_000080_create_sage_connections_table.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('sage_connections', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->unsignedBigInteger('team_id')->nullable();
+            $table->string('business_id')->nullable();
+            $table->text('access_token')->nullable();
+            $table->text('refresh_token')->nullable();
+            $table->timestamp('token_expires_at')->nullable();
+            $table->timestamp('last_synced_at')->nullable();
+            $table->string('status')->default('active');
+            $table->timestamps();
+
+            $table->unique(['user_id', 'business_id']);
+        });
+
+        Schema::table('invoices', function (Blueprint $table): void {
+            if (! Schema::hasColumn('invoices', 'sage_id')) {
+                $table->string('sage_id')->nullable()->index();
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('sage_connections');
+        Schema::table('invoices', function (Blueprint $table): void {
+            $table->dropColumn('sage_id');
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -13,6 +13,7 @@ use App\Http\Controllers\Api\QboController;
 use App\Http\Controllers\Api\QboWebhookController;
 use App\Http\Controllers\Api\RevolutController;
 use App\Http\Controllers\Api\RevolutWebhookController;
+use App\Http\Controllers\Api\SageController;
 use App\Http\Controllers\Api\TransactionController;
 use App\Http\Controllers\Api\WiseController;
 use App\Http\Controllers\Api\WiseWebhookController;
@@ -109,6 +110,13 @@ Route::middleware('auth:sanctum')->group(function (): void {
         Route::post('/connections/{connection}/pay', [RevolutController::class, 'sendPayment'])->middleware('throttle:30,1');
         Route::post('/connections/{connection}/bulk-pay', [RevolutController::class, 'sendBulkPayment'])->middleware('throttle:10,1');
         Route::delete('/connections/{connection}', [RevolutController::class, 'removeConnection']);
+    });
+
+    // Sage Accounting API Routes
+    Route::prefix('sage')->middleware('throttle:60,1')->group(function (): void {
+        Route::get('/connect', [SageController::class, 'connect']);
+        Route::get('/callback', [SageController::class, 'callback']);
+        Route::post('/connections/{connection}/sync', [SageController::class, 'sync'])->middleware('throttle:10,1');
     });
 
     // Xero API Routes

--- a/tests/Feature/Api/SageSyncTest.php
+++ b/tests/Feature/Api/SageSyncTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Models\Customer;
+use App\Models\Invoice;
+use App\Models\SageConnection;
+use App\Models\User;
+use App\Services\SageService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class SageSyncTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+
+        config()->set('services.sage', [
+            'client_id' => 'test_client',
+            'client_secret' => 'test_secret',
+            'redirect_uri' => 'https://app.test/api/sage/callback',
+            'authorization_url' => 'https://www.sageone.com/oauth2/auth/central',
+            'token_url' => 'https://oauth.accounting.sage.com/token',
+            'businesses_url' => 'https://api.accounting.sage.com/v3.1/businesses',
+            'api_base_url' => 'https://api.accounting.sage.com/v3.1',
+        ]);
+    }
+
+    private function connection(): SageConnection
+    {
+        return SageConnection::create([
+            'user_id' => $this->user->id,
+            'business_id' => 'biz-123',
+            'access_token' => 'at',
+            'refresh_token' => 'rt',
+            'token_expires_at' => now()->addHour(),
+            'status' => 'active',
+        ]);
+    }
+
+    private function service(): SageService
+    {
+        return app(SageService::class);
+    }
+
+    public function test_connect_returns_authorization_url(): void
+    {
+        $response = $this->actingAs($this->user)->getJson('/api/sage/connect');
+
+        $response->assertOk()->assertJsonStructure(['authorization_url']);
+        $this->assertStringContainsString('sageone.com/oauth2/auth/central', $response->json('authorization_url'));
+        $this->assertStringContainsString('client_id=test_client', $response->json('authorization_url'));
+    }
+
+    public function test_callback_exchanges_code_and_stores_connection(): void
+    {
+        Http::fake([
+            'oauth.accounting.sage.com/token' => Http::response(['access_token' => 'a', 'refresh_token' => 'r', 'expires_in' => 3600], 200),
+            'api.accounting.sage.com/v3.1/businesses' => Http::response(['$items' => [['id' => 'biz-xyz']]], 200),
+        ]);
+
+        $response = $this->actingAs($this->user)->getJson('/api/sage/callback?code=authcode');
+
+        $response->assertOk();
+        $this->assertDatabaseHas('sage_connections', ['user_id' => $this->user->id, 'business_id' => 'biz-xyz', 'status' => 'active']);
+    }
+
+    public function test_push_invoice_stores_remote_id(): void
+    {
+        Http::fake(['*/v3.1/sales_invoices*' => Http::response(['id' => 'sage-1'], 200)]);
+
+        $customer = Customer::factory()->create();
+        $invoice = Invoice::factory()->create(['customer_id' => $customer->id, 'total_amount' => 150]);
+
+        $this->service()->pushInvoice($invoice, $this->connection());
+
+        $this->assertSame('sage-1', $invoice->fresh()->sage_id);
+        Http::assertSent(fn ($r) => str_contains($r->url(), '/v3.1/sales_invoices') && $r->method() === 'POST');
+    }
+
+    public function test_pull_invoices_creates_local_invoices(): void
+    {
+        Http::fake(['*/v3.1/sales_invoices*' => Http::response(['$items' => [
+            ['id' => 'sage-9', 'displayed_as' => 'INV-S9', 'total_amount' => 320.50, 'date' => '2026-06-01', 'contact_name' => 'Globex'],
+        ]], 200)]);
+
+        $count = $this->service()->pullInvoices($this->connection());
+
+        $this->assertSame(1, $count);
+        $this->assertDatabaseHas('invoices', ['sage_id' => 'sage-9']);
+        $this->assertDatabaseHas('customers', ['customer_name' => 'Globex']);
+    }
+}


### PR DESCRIPTION
## F4 — Sage two-way invoice sync

Adds the third accounting-provider integration (after QBO #784 and Xero #805), mirroring their shape. Phase 3 P4 — the final follow-up.

### What's included
- **OAuth 2.0** — connect + callback (token exchange, then Sage business resolution via `/businesses`), encrypted tokens on `SageConnection`, `services.sage` config.
- **`SageService`** — `pushInvoice` (`sales_invoices`) and `pullInvoices` (Sage `$items`; `contact_name` → local `Customer`); adds `invoices.sage_id`.
- **`/api/sage/*`** routes — connect, callback, sync.

### Tests
- `SageSyncTest` (4): authorization URL, callback stores connection, invoice push stores remote id, pull creates local invoice + customer.
- Full suite: **312 passing**.

### Recommended next refactor (not in this PR)
Three providers (QBO, Xero, Sage) now share the same connect / refresh / upsert-by-remote-id shape. Extracting a shared provider-sync contract is the natural next step — kept separate here to avoid touching the two already-merged, working integrations.
