### PR TITLE
fix(schema): per-tenant account numbers; drop dead TaxForm calc

### DIFF
--- a/app/Models/TaxForm.php
+++ b/app/Models/TaxForm.php
@@ -52,37 +52,6 @@ class TaxForm extends Model
         return $pdf->download($this->form_type.'_'.$this->tax_year.'.pdf');
     }
 
-    public function calculateTotals(): void
-    {
-        $invoices = Invoice::where('customer_id', $this->customer_id)
-            ->whereYear('invoice_date', $this->tax_year)
-            ->get();
-
-        $this->total_payments = $invoices->sum('total_amount');
-        $this->total_tax_withheld = $invoices->sum('tax_amount');
-
-        // Calculate tax summaries by rate
-        $taxSummary = [];
-        foreach ($invoices as $invoice) {
-            if ($invoice->taxRate) {
-                $rateName = $invoice->taxRate->name;
-                if (! isset($taxSummary[$rateName])) {
-                    $taxSummary[$rateName] = [
-                        'rate' => $invoice->taxRate->rate,
-                        'amount' => 0,
-                    ];
-                }
-                $taxSummary[$rateName]['amount'] += $invoice->tax_amount;
-            }
-        }
-
-        $this->form_data = array_merge($this->form_data ?? [], [
-            'tax_summary' => $taxSummary,
-        ]);
-
-        $this->save();
-    }
-
     public function getTaxSummaryAttribute()
     {
         return $this->form_data['tax_summary'] ?? [];

--- a/database/migrations/2026_12_02_000000_scope_account_number_unique_to_user.php
+++ b/database/migrations/2026_12_02_000000_scope_account_number_unique_to_user.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Replace the global unique on account_number with a per-user composite,
+     * matching the per-tenant validation (Rule::unique(...)->where('user_id', ...)).
+     */
+    public function up(): void
+    {
+        Schema::table('accounts', function (Blueprint $table): void {
+            // drops the inline index `accounts_account_number_unique`
+            $table->dropUnique(['account_number']);
+            $table->unique(['user_id', 'account_number']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('accounts', function (Blueprint $table): void {
+            $table->dropUnique(['user_id', 'account_number']);
+            $table->unique(['account_number']);
+        });
+    }
+};

--- a/tests/Feature/AccountNumberUniquenessTest.php
+++ b/tests/Feature/AccountNumberUniquenessTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Account;
+use App\Models\User;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AccountNumberUniquenessTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_two_users_can_hold_the_same_account_number(): void
+    {
+        $userA = User::factory()->create();
+        $userB = User::factory()->create();
+
+        Account::factory()->create(['user_id' => $userA->id, 'account_number' => 1000]);
+        Account::factory()->create(['user_id' => $userB->id, 'account_number' => 1000]);
+
+        $this->assertSame(2, Account::where('account_number', 1000)->count());
+    }
+
+    public function test_same_user_cannot_reuse_an_account_number(): void
+    {
+        $user = User::factory()->create();
+
+        Account::factory()->create(['user_id' => $user->id, 'account_number' => 1000]);
+
+        $this->expectException(QueryException::class);
+        Account::factory()->create(['user_id' => $user->id, 'account_number' => 1000]);
+    }
+}

--- a/tests/Unit/Models/TaxFormTest.php
+++ b/tests/Unit/Models/TaxFormTest.php
@@ -30,15 +30,4 @@ class TaxFormTest extends TestCase
 
         $this->assertSame([], $form->tax_summary);
     }
-
-    public function test_calculate_totals_is_unreachable_on_current_schema(): void
-    {
-        // calculateTotals() reads $invoice->tax_amount and $invoice->taxRate
-        // (via tax_rate_id) to build total_tax_withheld and the per-rate
-        // tax_summary. The migrated `invoices` table has neither `tax_amount`
-        // nor `tax_rate_id` columns, and with strict attribute checking on,
-        // resolving $invoice->taxRate throws MissingAttributeException for
-        // tax_rate_id — so the whole method blows up before it can sum anything.
-        $this->markTestSkipped('BUG: invoices table has no tax_amount/tax_rate_id columns; TaxForm::calculateTotals() throws MissingAttributeException (tax_rate_id) and cannot run.');
-    }
 }


### PR DESCRIPTION
## Summary

Two schema/dead-code follow-ups from the P0 batch. Full suite **405 pass, 0 skips**.

### P0-3b — per-tenant account numbers
`accounts.account_number` had a **global** unique index. PR #816 made the API validate uniqueness per `user_id`, so two tenants with the same number passed validation but the second INSERT hit the global index → 500. New migration drops the global unique and adds composite `unique(user_id, account_number)`; the DB now matches the validation. Test: two tenants can share `1000`; the same tenant cannot.

### P0-6b — remove dead `TaxForm::calculateTotals()`
It was unreachable (needs `invoices.tax_rate_id`, which doesn't exist on the live table) and had **no caller** — the TaxForm Filament pages never invoke it; every `calculateTotals(` hit in `app/` is on a different model. Deleted the method (YAGNI). Kept `getTaxSummary` accessor (used by the `1099-misc` PDF view). This removes the `markTestSkipped` from #817.

## Follow-up surfaced (needs verification)

**P0-6c** — `Invoice::calculateTotals()` **is** live (called from `InvoiceItem`) and reads the same missing `invoices.tax_amount` / `tax_rate_id` columns (present only in the disabled `2024_02_20` migration). Under strict-attribute mode this could 500 on invoice-item save. The suite is green (so it's conditional, not always-on), but the Invoice tax model needs reconciling — likely tax belongs on `invoice_items`, not the invoice. Tracked separately.
