### PR TITLE
fix(teams): restore TeamManagementService (P0-T phase 0)

### DIFF
--- a/app/Services/TeamManagementService.php
+++ b/app/Services/TeamManagementService.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Team provisioning. Guarantees every user owns exactly one personal team,
+ * which is their tenant (Filament resolves the tenant from owned teams).
+ *
+ * Restores the class the registration flow (CreateNewUserWithTeams) and the
+ * CreatePersonalTeam listener already depend on — it was referenced but never
+ * existed, so registration fataled and no personal teams were created.
+ */
+class TeamManagementService
+{
+    /**
+     * Ensure the user owns a personal team and has it selected. Idempotent:
+     * safe to call from both the Fortify create action and the Registered
+     * listener, and safe to call repeatedly — it never creates a second
+     * personal team.
+     */
+    public function createPersonalTeamForUser(User $user): Team
+    {
+        return DB::transaction(function () use ($user): Team {
+            $team = $user->ownedTeams()->where('personal_team', true)->first();
+
+            if (! $team instanceof Team) {
+                $team = Team::forceCreate([
+                    'user_id' => $user->getKey(),
+                    'name' => explode(' ', (string) $user->name)[0]."'s Team",
+                    'personal_team' => true,
+                ]);
+            }
+
+            // The user owns the team, so belongsToTeam() is true and switchTeam succeeds.
+            if ($user->current_team_id === null) {
+                $user->switchTeam($team);
+            }
+
+            return $team;
+        });
+    }
+
+    /**
+     * ponytail: a user's default tenant IS their own personal team — isolation
+     * over a shared "team 1" bucket. Both entry points converge on one team.
+     */
+    public function assignUserToDefaultTeam(User $user): void
+    {
+        $this->createPersonalTeamForUser($user);
+    }
+}

--- a/tests/Feature/TeamManagementServiceTest.php
+++ b/tests/Feature/TeamManagementServiceTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Services\TeamManagementService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * P0-T Phase 0: team provisioning (TeamManagementService was missing → registration
+ * fataled and no personal teams existed, blocking a deterministic team_id backfill).
+ */
+class TeamManagementServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_creates_a_personal_team_and_selects_it(): void
+    {
+        $user = User::factory()->create(['name' => 'Ada Lovelace', 'current_team_id' => null]);
+
+        $team = app(TeamManagementService::class)->createPersonalTeamForUser($user);
+        $user->refresh();
+
+        $this->assertTrue((bool) $team->personal_team);
+        $this->assertSame($user->getKey(), $team->user_id, 'user owns the team');
+        $this->assertSame($team->getKey(), $user->current_team_id, 'personal team is selected');
+        $this->assertSame(1, $user->ownedTeams()->where('personal_team', true)->count());
+    }
+
+    public function test_provisioning_is_idempotent(): void
+    {
+        $user = User::factory()->create(['current_team_id' => null]);
+        $svc = app(TeamManagementService::class);
+
+        $svc->createPersonalTeamForUser($user);
+        $svc->assignUserToDefaultTeam($user);        // second entry point
+        $svc->createPersonalTeamForUser($user);      // repeat
+
+        // Never a second personal team.
+        $this->assertSame(1, $user->fresh()->ownedTeams()->where('personal_team', true)->count());
+    }
+}


### PR DESCRIPTION
## Summary

**Phase 0 of P0-T** (unify tenancy on Team). Restores `App\Services\TeamManagementService`, which registration and the `CreatePersonalTeam` listener both `use`/inject but which **did not exist in the repo** — so the reference fataled and no personal teams were ever created.

Full suite **407 pass**; PHPStan level max `[OK]` on the new service.

## What it does

Idempotent team provisioning: guarantees every user **owns exactly one personal team** and has it selected (`current_team_id`). Both entry points (`createPersonalTeamForUser`, `assignUserToDefaultTeam`) converge on the same team; safe to call repeatedly — never creates a second personal team.

## Why now

Discovered while auditing the tenancy root cause (4 read-only mappers). The app's real ownership discriminator is `user_id`; `team_id` is a meaningless constant `1` (`->default(1)` no-op). Making Team the true tenant needs a deterministic `user_id → team_id` backfill — which requires **one owned team per user** first. Provisioning being broken was the blocker. This unblocks Phase 1 (backfill).

## Approach decision (for reviewers)

P0-T will be **explicit Team scoping, not a global scope**. A magic `addGlobalScope` on `IsTenantModel` would need ~11 tenantless bypass sites (jobs, webhooks, scheduled batch commands, dunning notifications, seeders), NULL-team semantics, and separate API-tenant resolution — a bug farm. Instead: Filament already team-scopes panels; subsequent phases make the API + create-hooks consistently use `team_id`. Full phased plan in the repo-root `TASKS.md`.

## Not in this PR (tracked)

Phase 1 backfill migration; Phase 2 create-hook/API switch to `team_id`; Phase 3 cleanup (de-tenant global-ref models, fix `GeneralLedgerReportResource` with no table, correct the false `IsTenantModel` claim in `src/CLAUDE.md`). Unrelated bugs surfaced: undefined `Invoice::calculateLateFee()`; `SiteSettings`↔`settings` table-name mismatch.
