### PR TITLE
feat(teams): idempotent tenancy backfill command (P0-T phase 1)

### DIFF
--- a/app/Console/Commands/BackfillTenancy.php
+++ b/app/Console/Commands/BackfillTenancy.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\Team;
+use App\Models\User;
+use App\Services\TeamManagementService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * P0-T Phase 1: one-off, idempotent tenancy backfill for existing deployments.
+ *
+ * 1. Ensures every user owns a personal team (their tenant) with it selected.
+ * 2. Fills NULL team_id on the user-owned tables from each row's user's team.
+ *
+ * Conservative by design: only touches rows where team_id IS NULL, so it never
+ * reassigns an already-scoped row and is safe to re-run.
+ */
+class BackfillTenancy extends Command
+{
+    #[\Override]
+    protected $signature = 'teams:backfill-tenancy {--dry-run : Report what would change without writing}';
+
+    #[\Override]
+    protected $description = 'Provision personal teams for existing users and backfill NULL team_id from user_id';
+
+    /**
+     * Tables carrying user_id that predate team_id being stamped on create.
+     */
+    private const USER_OWNED_TABLES = [
+        'accounts', 'transactions', 'journal_entries', 'bank_connections',
+        'expenses', 'audit_logs', 'connected_accounts',
+        'qbo_connections', 'xero_connections', 'sage_connections',
+    ];
+
+    public function handle(TeamManagementService $teams): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+
+        // 1. Provision — every user needs exactly one owned personal team, selected.
+        // The service is idempotent (creates only if missing, sets current_team_id
+        // only if null), so call it for everyone and just count the new teams.
+        $provisioned = 0;
+        User::query()->each(function (User $user) use ($teams, $dryRun, &$provisioned): void {
+            if (! $user->ownedTeams()->where('personal_team', true)->exists()) {
+                $provisioned++;
+            }
+            if (! $dryRun) {
+                $teams->createPersonalTeamForUser($user);
+            }
+        });
+        $this->info(($dryRun ? '[dry-run] ' : '')."Provisioned personal teams for {$provisioned} user(s).");
+
+        // 2. Backfill NULL team_id from each row's user's personal team.
+        $filled = 0;
+        Team::query()->where('personal_team', true)->each(function (Team $team) use ($dryRun, &$filled): void {
+            foreach (self::USER_OWNED_TABLES as $table) {
+                if (! Schema::hasColumn($table, 'team_id') || ! Schema::hasColumn($table, 'user_id')) {
+                    continue;
+                }
+                $q = DB::table($table)->whereNull('team_id')->where('user_id', $team->user_id);
+                $count = (clone $q)->count();
+                if ($count === 0) {
+                    continue;
+                }
+                $filled += $count;
+                if (! $dryRun) {
+                    $q->update(['team_id' => $team->getKey()]);
+                }
+            }
+        });
+        $this->info(($dryRun ? '[dry-run] ' : '')."Backfilled team_id on {$filled} row(s).");
+
+        return self::SUCCESS;
+    }
+}

--- a/tests/Feature/BackfillTenancyTest.php
+++ b/tests/Feature/BackfillTenancyTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Account;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * P0-T Phase 1: idempotent tenancy backfill (teams:backfill-tenancy).
+ */
+class BackfillTenancyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_provisions_teams_and_backfills_null_team_id(): void
+    {
+        $user = User::factory()->create(['current_team_id' => null]);
+        $nullRow = Account::factory()->create(['user_id' => $user->id, 'team_id' => null]);
+
+        // A row already scoped to a different team must NOT be reassigned.
+        $otherTeam = Team::forceCreate(['user_id' => $user->id, 'name' => 'Books', 'personal_team' => false]);
+        $assignedRow = Account::factory()->create(['user_id' => $user->id, 'team_id' => $otherTeam->id]);
+
+        $this->artisan('teams:backfill-tenancy')->assertSuccessful();
+
+        $user->refresh();
+        $personal = $user->ownedTeams()->where('personal_team', true)->first();
+        $this->assertNotNull($personal, 'personal team provisioned');
+        $this->assertSame($personal->id, $user->current_team_id, 'current team selected');
+        $this->assertSame($personal->id, $nullRow->fresh()->team_id, 'NULL team_id backfilled from user');
+        $this->assertSame($otherTeam->id, $assignedRow->fresh()->team_id, 'already-scoped row untouched');
+    }
+
+    public function test_dry_run_writes_nothing(): void
+    {
+        $user = User::factory()->create(['current_team_id' => null]);
+        $row = Account::factory()->create(['user_id' => $user->id, 'team_id' => null]);
+
+        $this->artisan('teams:backfill-tenancy', ['--dry-run' => true])->assertSuccessful();
+
+        $this->assertNull($row->fresh()->team_id, 'no write in dry-run');
+        $this->assertFalse(
+            $user->fresh()->ownedTeams()->where('personal_team', true)->exists(),
+            'no team provisioned in dry-run',
+        );
+    }
+}


### PR DESCRIPTION
## Summary

**P0-T Phase 1** — an idempotent `teams:backfill-tenancy` command for existing deployments. Full suite **411 pass**; PHPStan level max `[OK]`.

Two steps:
1. **Provision** — ensure every existing user owns a personal team and has it selected (`current_team_id`). Uses the `TeamManagementService` from Phase 0 (idempotent).
2. **Backfill** — fill `NULL` `team_id` on the ten `user_id`-bearing tables (`accounts`, `transactions`, `journal_entries`, `bank_connections`, `expenses`, `audit_logs`, `connected_accounts`, `qbo/xero/sage_connections`) from each row's user's personal team.

## Safety

- **Only touches `team_id IS NULL`** — never reassigns a row that already has a team, so it can't scramble already-scoped data and is safe to re-run.
- `--dry-run` reports counts without writing.
- Tested: NULL rows get backfilled to the user's team; a row pre-scoped to a *different* team is left untouched; dry-run writes nothing.

## Why a command, not an auto-migration

A data migration runs on empty tables during `migrate:fresh` (so it's untestable and pointless on fresh installs) and couples migration history to app services. This is a one-off for **existing** data — ops runs it once post-deploy. Fresh installs need nothing (new rows get `team_id` stamped on create, PR #820).

## Caveat for operators

The backfill assigns each user's rows to **their own personal team**. If a deployment has multiple users who were *sharing* one organisation's books, run `--dry-run` first and review — this splits rows by creating user. Consistent with the per-user-tenant model (Phase 0). Next: Phase 2b switches API read scoping `user_id → team_id` (safe once this backfill has run).
