### PR TITLE
refactor(gl): scope GeneralLedgerService by team (P0-T 2b, GL slice)

### DIFF
--- a/app/Services/GeneralLedgerService.php
+++ b/app/Services/GeneralLedgerService.php
@@ -12,14 +12,25 @@ class GeneralLedgerService
 {
     public function __construct(protected ExchangeRateService $exchangeRateService) {}
 
+    /**
+     * The acting user's current team, or -1 when there is none — a sentinel that
+     * matches no row (team ids are positive), so a tenantless call returns empty
+     * rather than leaking every unassigned (team_id IS NULL) row.
+     */
+    private function scopedTeamId(): int
+    {
+        // GL is only reached in authenticated contexts (Sanctum API, Filament panel).
+        return auth()->user()->current_team_id ?? -1;
+    }
+
     public function getAccountBalances($startDate, $endDate, ?Currency $displayCurrency = null)
     {
         if (! $displayCurrency instanceof Currency) {
             $displayCurrency = Currency::where('is_default', true)->first();
         }
 
-        // ponytail: tenant-scope by user_id (accounts carry no team_id yet); replace with team scope when team_id lands. Null auth = empty set (safe, no leak).
-        return Account::where('user_id', auth()->id())
+        // Tenant-scope by team. Null current team -> -1 sentinel = empty result.
+        return Account::where('team_id', $this->scopedTeamId())
             ->with(['transactions' => function ($query) use ($startDate, $endDate): void {
                 $query->whereBetween('transaction_date', [$startDate, $endDate]);
             }])
@@ -62,8 +73,8 @@ class GeneralLedgerService
             $displayCurrency = Currency::where('is_default', true)->first();
         }
 
-        // ponytail: tenant-scope by user_id — see getAccountBalances note.
-        return Account::where('user_id', auth()->id())
+        // Tenant-scope by team — see getAccountBalances note.
+        return Account::where('team_id', $this->scopedTeamId())
             ->with(['transactions' => function ($query) use ($date): void {
                 $query->where('transaction_date', '<=', $date);
             }])
@@ -103,28 +114,28 @@ class GeneralLedgerService
 
         // Get current month revenue
         $revenue = Transaction::whereHas('account', function ($query): void {
-            $query->where('account_type', 'revenue')->where('user_id', auth()->id());
+            $query->where('account_type', 'revenue')->where('team_id', $this->scopedTeamId());
         })
             ->whereBetween('transaction_date', [$startDate, $endDate])
             ->sum('amount');
 
         // Get previous month revenue for comparison
         $previousRevenue = Transaction::whereHas('account', function ($query): void {
-            $query->where('account_type', 'revenue')->where('user_id', auth()->id());
+            $query->where('account_type', 'revenue')->where('team_id', $this->scopedTeamId());
         })
             ->whereBetween('transaction_date', [$previousStartDate, $previousEndDate])
             ->sum('amount');
 
         // Get current month expenses
         $expenses = Transaction::whereHas('account', function ($query): void {
-            $query->where('account_type', 'expense')->where('user_id', auth()->id());
+            $query->where('account_type', 'expense')->where('team_id', $this->scopedTeamId());
         })
             ->whereBetween('transaction_date', [$startDate, $endDate])
             ->sum('amount');
 
         // Get previous month expenses for comparison
         $previousExpenses = Transaction::whereHas('account', function ($query): void {
-            $query->where('account_type', 'expense')->where('user_id', auth()->id());
+            $query->where('account_type', 'expense')->where('team_id', $this->scopedTeamId());
         })
             ->whereBetween('transaction_date', [$previousStartDate, $previousEndDate])
             ->sum('amount');
@@ -166,7 +177,7 @@ class GeneralLedgerService
             $currentDate = (clone $startDate)->addDays($i);
 
             $amount = Transaction::whereHas('account', function ($query) use ($accountType): void {
-                $query->where('account_type', $accountType)->where('user_id', auth()->id());
+                $query->where('account_type', $accountType)->where('team_id', $this->scopedTeamId());
             })
                 ->whereDate('transaction_date', $currentDate)
                 ->sum('amount');

--- a/tests/Feature/Api/GeneralLedgerApiTest.php
+++ b/tests/Feature/Api/GeneralLedgerApiTest.php
@@ -6,6 +6,7 @@ namespace Tests\Feature\Api;
 
 use App\Models\Account;
 use App\Models\User;
+use App\Services\TeamManagementService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -19,6 +20,8 @@ class GeneralLedgerApiTest extends TestCase
     {
         parent::setUp();
         $this->user = User::factory()->create();
+        app(TeamManagementService::class)->createPersonalTeamForUser($this->user);
+        $this->user->refresh();
     }
 
     public function test_trial_balance_requires_authentication(): void
@@ -28,7 +31,7 @@ class GeneralLedgerApiTest extends TestCase
 
     public function test_trial_balance_returns_rows(): void
     {
-        Account::factory()->create(['user_id' => $this->user->id, 'account_type' => 'asset', 'normal_balance' => 'debit', 'balance' => 500]);
+        Account::factory()->create(['team_id' => $this->user->current_team_id, 'account_type' => 'asset', 'normal_balance' => 'debit', 'balance' => 500]);
 
         $response = $this->actingAs($this->user)->getJson('/api/general-ledger/trial-balance');
 

--- a/tests/Feature/ReportingCurrencyTest.php
+++ b/tests/Feature/ReportingCurrencyTest.php
@@ -9,6 +9,7 @@ use App\Models\Currency;
 use App\Models\ExchangeRate;
 use App\Models\User;
 use App\Services\GeneralLedgerService;
+use App\Services\TeamManagementService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -22,12 +23,13 @@ class ReportingCurrencyTest extends TestCase
         $eur = Currency::create(['code' => 'EUR', 'name' => 'Euro', 'symbol' => '€', 'is_default' => false]);
         ExchangeRate::create(['from_currency_id' => $usd->currency_id, 'to_currency_id' => $eur->currency_id, 'rate' => 0.90, 'date' => now()->toDateString()]);
 
-        // GL reports are tenant-scoped (P0-1): act as the account owner.
+        // GL reports are tenant-scoped by team (P0-T 2b): act as a member of the account's team.
         $user = User::factory()->create();
-        $this->actingAs($user);
+        $team = app(TeamManagementService::class)->createPersonalTeamForUser($user);
+        $this->actingAs($user->fresh());
 
         // Account holds 1000 in the default currency (no explicit currency = default).
-        Account::factory()->create(['user_id' => $user->id, 'account_type' => 'asset', 'normal_balance' => 'debit', 'balance' => 1000]);
+        Account::factory()->create(['team_id' => $team->getKey(), 'account_type' => 'asset', 'normal_balance' => 'debit', 'balance' => 1000]);
 
         $rows = app(GeneralLedgerService::class)->getTrialBalance(now(), $eur);
 

--- a/tests/Feature/Services/GeneralLedgerTenantScopingTest.php
+++ b/tests/Feature/Services/GeneralLedgerTenantScopingTest.php
@@ -7,24 +7,36 @@ namespace Tests\Feature\Services;
 use App\Models\Account;
 use App\Models\User;
 use App\Services\GeneralLedgerService;
+use App\Services\TeamManagementService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 /**
- * P0-1 regression: GL reports must not leak another tenant's accounts.
- * Before the fix, Account::...->get() returned every user's accounts.
+ * P0-1 / P0-T 2b regression: GL reports must not leak another tenant's accounts.
+ * Scoping is by the acting user's current team (was user_id before P0-T).
  */
 class GeneralLedgerTenantScopingTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_account_balances_only_return_the_acting_users_accounts(): void
+    /** @return array{0: User, 1: Account, 2: Account} acting user, own account, other team's account */
+    private function twoTenants(): array
     {
+        $teams = app(TeamManagementService::class);
         $userA = User::factory()->create();
         $userB = User::factory()->create();
+        $teamA = $teams->createPersonalTeamForUser($userA);
+        $teamB = $teams->createPersonalTeamForUser($userB);
 
-        $mine = Account::factory()->create(['user_id' => $userA->id, 'account_type' => 'asset', 'normal_balance' => 'debit', 'balance' => 100]);
-        $theirs = Account::factory()->create(['user_id' => $userB->id, 'account_type' => 'asset', 'normal_balance' => 'debit', 'balance' => 999]);
+        $mine = Account::factory()->create(['team_id' => $teamA->getKey(), 'account_type' => 'asset', 'normal_balance' => 'debit', 'balance' => 100]);
+        $theirs = Account::factory()->create(['team_id' => $teamB->getKey(), 'account_type' => 'asset', 'normal_balance' => 'debit', 'balance' => 999]);
+
+        return [$userA->fresh(), $mine, $theirs];
+    }
+
+    public function test_account_balances_only_return_the_acting_teams_accounts(): void
+    {
+        [$userA, $mine, $theirs] = $this->twoTenants();
 
         $this->actingAs($userA);
         $ids = app(GeneralLedgerService::class)->getAccountBalances(now()->subYear(), now())->pluck('account_id');
@@ -33,13 +45,9 @@ class GeneralLedgerTenantScopingTest extends TestCase
         $this->assertFalse($ids->contains($theirs->getKey()), 'LEAK: another tenant\'s account exposed');
     }
 
-    public function test_trial_balance_only_returns_the_acting_users_accounts(): void
+    public function test_trial_balance_only_returns_the_acting_teams_accounts(): void
     {
-        $userA = User::factory()->create();
-        $userB = User::factory()->create();
-
-        $mine = Account::factory()->create(['user_id' => $userA->id, 'account_type' => 'asset', 'normal_balance' => 'debit', 'balance' => 100]);
-        $theirs = Account::factory()->create(['user_id' => $userB->id, 'account_type' => 'asset', 'normal_balance' => 'debit', 'balance' => 999]);
+        [$userA, $mine, $theirs] = $this->twoTenants();
 
         $this->actingAs($userA);
         $ids = app(GeneralLedgerService::class)->getTrialBalance(now())->pluck('account_id');


### PR DESCRIPTION
## Summary

**P0-T Phase 2b — GL slice.** `GeneralLedgerService` (account balances, trial balance, key metrics, chart data) now scopes by the acting user's **current team** instead of `user_id`. The P0-1 leak fix scoped by `user_id` as a stopgap; this completes the Team-tenant migration for the GL surface. Full suite **411 pass**; PHPStan level max `[OK]`.

## Safety

- Null current team → a `-1` sentinel that matches no row (team ids are positive), so a tenantless call returns **empty** — never `team_id IS NULL`, which would leak every unassigned row.
- Reachable only in authenticated contexts (Sanctum API, Filament dashboard widget), where a current team is present after the Phase 1 backfill.

## Prerequisite

Depends on the Phase 1 backfill (`teams:backfill-tenancy`, #821) having run: existing accounts must carry `team_id` and users must have `current_team_id`, or GL returns empty for them. New rows are covered by Phase 2a stamping (#820).

## Tests

Updated `GeneralLedgerTenantScopingTest`, `GeneralLedgerApiTest`, `ReportingCurrencyTest` to provision teams and create team-scoped accounts. The cross-tenant leak assertion is preserved (team B's accounts never appear for team A).

## Next (same pattern)

The remaining `user_id`-scoped API controllers — `Transaction`, `JournalEntry`, `ChartOfAccount`, and the bank/accounting connections — follow this exact pattern (`where('team_id', currentTeamId)` + `-1` sentinel). Invoice/Bill/Estimate already scope by team.
