### PR TITLE
fix(banking): bank_connections encrypted tokens overflow VARCHAR on MySQL

### DIFF
--- a/database/migrations/2026_12_05_000000_widen_bank_connection_token_columns.php
+++ b/database/migrations/2026_12_05_000000_widen_bank_connection_token_columns.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Columns on bank_connections that carry Laravel `encrypted`-cast values.
+     * The ciphertext (base64 JSON envelope) runs ~200-400 chars for a token,
+     * overflowing the original VARCHAR(255). SQLite ignores the length limit so
+     * the test suite stayed green, but MySQL/prod rejects the insert with
+     * "SQLSTATE[22001] Data too long" — so bank connections could not persist
+     * their tokens in production. Widen to TEXT (sage/qbo/xero connections
+     * already use TEXT for the same reason).
+     */
+    private const COLUMNS = [
+        'plaid_access_token',
+        'revolut_access_token',
+        'revolut_refresh_token',
+        'wise_access_token',
+        'wise_refresh_token',
+    ];
+
+    public function up(): void
+    {
+        Schema::table('bank_connections', function (Blueprint $table): void {
+            foreach (self::COLUMNS as $col) {
+                if (Schema::hasColumn('bank_connections', $col)) {
+                    $table->text($col)->nullable()->change();
+                }
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('bank_connections', function (Blueprint $table): void {
+            foreach (self::COLUMNS as $col) {
+                if (Schema::hasColumn('bank_connections', $col)) {
+                    $table->string($col)->nullable()->change();
+                }
+            }
+        });
+    }
+};

--- a/tests/Feature/BankConnectionTokenColumnTest.php
+++ b/tests/Feature/BankConnectionTokenColumnTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\BankConnection;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class BankConnectionTokenColumnTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Guards on ANY driver (SQLite included): the encrypted-token columns must be
+     * TEXT, not VARCHAR(255), or the encrypted ciphertext overflows on MySQL/prod.
+     */
+    public function test_encrypted_token_columns_are_text(): void
+    {
+        foreach ([
+            'plaid_access_token',
+            'revolut_access_token',
+            'revolut_refresh_token',
+            'wise_access_token',
+            'wise_refresh_token',
+        ] as $col) {
+            $this->assertSame(
+                'text',
+                Schema::getColumnType('bank_connections', $col),
+                "bank_connections.{$col} must be TEXT to hold an encrypted token",
+            );
+        }
+    }
+
+    /**
+     * A realistically long encrypted token round-trips. Fails on MySQL pre-fix
+     * ("Data too long"); harmless on SQLite (no length enforcement).
+     */
+    public function test_long_encrypted_token_round_trips(): void
+    {
+        $long = str_repeat('x', 500);
+
+        $connection = BankConnection::factory()->create(['plaid_access_token' => $long]);
+
+        $this->assertSame($long, $connection->fresh()->plaid_access_token);
+    }
+}


### PR DESCRIPTION
🔴 **Prod-breaking, SQLite-masked.** `bank_connections` stores five `encrypted`-cast token columns (`plaid_access_token`, `revolut_access_token`, `revolut_refresh_token`, `wise_access_token`, `wise_refresh_token`) as **`VARCHAR(255)`**. Laravel's `encrypted` cast produces a base64 JSON envelope ~200–400 chars, which overflows 255. **SQLite ignores VARCHAR length** so the whole test suite was green; **MySQL/prod enforces it** → `SQLSTATE[22001] Data too long` on insert → **bank connections cannot persist their tokens in production** (Plaid/Revolut/Wise integrations broken).

### How it was found
Ran the full suite against the real **MySQL** dev DB (not the default SQLite `:memory:`). Result: **42 failures, every one this single root cause** — and zero "Unknown column" errors, confirming no *other* hidden schema bugs remain in tested paths. After the fix, the full suite passes on **both** SQLite (440) **and MySQL (440, was 42-failed)**.

### Fix
One migration widening the five columns to `TEXT` (via `->change()`) — matching `sage/qbo/xero_connections`, which already learned this and use `TEXT`. `credentials` was already `TEXT`; plaintext id columns (`plaid_item_id`, etc.) left as-is.

### Regression guard
`BankConnectionTokenColumnTest`: (a) asserts the five columns are `TEXT` — guards on **any** driver, including SQLite (fails pre-migration); (b) round-trips a 500-char token.

### Follow-up (reiterating #838's note, now proven high-value)
Add a **MySQL CI job**. This class of bug (VARCHAR overflow, wrong column names — cf. the FinancialStatementService fixes in #838) is **invisible** to the SQLite suite and only surfaces in prod. One MySQL run caught 42 failures the green suite hid.