### PR TITLE
fix: reconcile model fillable with schema; resurrect Projects (P0-11)

### DIFF
--- a/app/Models/Budget.php
+++ b/app/Models/Budget.php
@@ -25,7 +25,6 @@ class Budget extends Model
         'forecast_amount',
         'forecast_method',
         'is_approved',
-        'category',
     ];
 
     #[\Override]

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -11,8 +11,9 @@ class Category extends Model
 {
     use HasFactory;
 
-    #[\Override]
-    protected $primaryKey = 'category_id';
+    // ponytail: primaryKey defaults to `id` — the table is created with $table->id()
+    // and every external FK (inventory_items, expenses) constrains against categories.id,
+    // so the old `category_id` override was fictional and broke parent()/children().
 
     #[\Override]
     protected $fillable = [

--- a/app/Models/SiteSettings.php
+++ b/app/Models/SiteSettings.php
@@ -13,6 +13,11 @@ class SiteSettings extends Model
     use HasFactory;
     use IsTenantModel;
 
+    // ponytail: real table is `settings` (see create_site_settings_table migration);
+    // Eloquent would otherwise pluralize to the non-existent `site_settings`.
+    #[\Override]
+    protected $table = 'settings';
+
     #[\Override]
     protected $fillable = [
         'name',

--- a/database/factories/ProjectFactory.php
+++ b/database/factories/ProjectFactory.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\Project;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Project>
+ */
+class ProjectFactory extends Factory
+{
+    protected $model = Project::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $start = $this->faker->dateTimeBetween('-6 months', 'now');
+        $end = $this->faker->dateTimeBetween($start, '+6 months');
+
+        return [
+            'name' => $this->faker->unique()->company().' Project',
+            'code' => strtoupper($this->faker->unique()->bothify('PRJ-####')),
+            'description' => $this->faker->optional()->sentence(),
+            'start_date' => $start->format('Y-m-d'),
+            'end_date' => $end->format('Y-m-d'),
+            'status' => $this->faker->randomElement(['active', 'on_hold', 'completed']),
+            'allocation_percentage' => $this->faker->randomFloat(2, 10, 100),
+        ];
+    }
+}

--- a/database/migrations/2026_07_02_000001_add_notes_to_invoices_table.php
+++ b/database/migrations/2026_07_02_000001_add_notes_to_invoices_table.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('invoices', function (Blueprint $table): void {
+            if (! Schema::hasColumn('invoices', 'notes')) {
+                $table->text('notes')->nullable();
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('invoices', function (Blueprint $table): void {
+            $table->dropColumn('notes');
+        });
+    }
+};

--- a/database/migrations/2026_07_02_000002_add_parent_id_to_categories_table.php
+++ b/database/migrations/2026_07_02_000002_add_parent_id_to_categories_table.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('categories', function (Blueprint $table): void {
+            if (! Schema::hasColumn('categories', 'parent_id')) {
+                $table->foreignId('parent_id')->nullable()->constrained('categories')->nullOnDelete();
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('categories', function (Blueprint $table): void {
+            $table->dropConstrainedForeignId('parent_id');
+        });
+    }
+};

--- a/database/migrations/2026_07_02_000003_add_number_of_days_to_payment_terms_table.php
+++ b/database/migrations/2026_07_02_000003_add_number_of_days_to_payment_terms_table.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('payment_terms', function (Blueprint $table): void {
+            if (! Schema::hasColumn('payment_terms', 'payment_term_number_of_days')) {
+                $table->integer('payment_term_number_of_days')->nullable();
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('payment_terms', function (Blueprint $table): void {
+            $table->dropColumn('payment_term_number_of_days');
+        });
+    }
+};

--- a/database/migrations/2026_07_02_000010_create_projects_table.php
+++ b/database/migrations/2026_07_02_000010_create_projects_table.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('projects', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('team_id')->nullable()->constrained()->nullOnDelete();
+            // Columns mirror App\Models\Project::$fillable exactly (mass-assignment).
+            $table->string('name');
+            $table->string('code')->nullable();
+            $table->text('description')->nullable();
+            $table->date('start_date')->nullable();
+            $table->date('end_date')->nullable();
+            $table->string('status')->default('active');
+            $table->decimal('allocation_percentage', 5, 2)->nullable();
+            $table->timestamps();
+
+            $table->index('team_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('projects');
+    }
+};

--- a/database/migrations/2026_07_02_000020_add_project_id_to_tables.php
+++ b/database/migrations/2026_07_02_000020_add_project_id_to_tables.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Tables whose models reference project_id / a project() relation, plus
+     * transactions (Project::transactions() hasMany + Budget::getActualAmount()).
+     *
+     * @var list<string>
+     */
+    protected array $tables = [
+        'budgets',
+        'expenses',
+        'estimates',
+        'invoices',
+        'time_entries',
+        'transactions',
+    ];
+
+    public function up(): void
+    {
+        foreach ($this->tables as $table) {
+            if (Schema::hasTable($table) && ! Schema::hasColumn($table, 'project_id')) {
+                Schema::table($table, function (Blueprint $table): void {
+                    $table->foreignId('project_id')->nullable()->constrained('projects')->nullOnDelete();
+                });
+            }
+        }
+    }
+
+    public function down(): void
+    {
+        foreach ($this->tables as $table) {
+            if (Schema::hasTable($table) && Schema::hasColumn($table, 'project_id')) {
+                Schema::table($table, function (Blueprint $table): void {
+                    $table->dropForeign(['project_id']);
+                    $table->dropColumn('project_id');
+                });
+            }
+        }
+    }
+};

--- a/database/migrations/2026_11_27_000000_add_cost_allocation_fields_to_expenses_table.php
+++ b/database/migrations/2026_11_27_000000_add_cost_allocation_fields_to_expenses_table.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('expenses', function (Blueprint $table): void {
+            $table->boolean('is_indirect')->default(false);
+            $table->decimal('allocation_percentage', 5, 2)->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('expenses', function (Blueprint $table): void {
+            $table->dropColumn(['is_indirect', 'allocation_percentage']);
+        });
+    }
+};

--- a/tests/Feature/ExpenseBudgetFillableSchemaTest.php
+++ b/tests/Feature/ExpenseBudgetFillableSchemaTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Budget;
+use App\Models\Expense;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Every Expense/Budget $fillable entry (except project_id, owned by the Project
+ * feature) must map to a real column. is_indirect + allocation_percentage now
+ * have columns (wired via ProjectReportService); Budget::category was a dead
+ * cost-allocation stub and was removed from $fillable.
+ */
+class ExpenseBudgetFillableSchemaTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_expense_mass_assigns_cost_allocation_columns(): void
+    {
+        $expense = Expense::create([
+            'user_id' => User::factory()->create()->id,
+            'description' => 'shared server rent',
+            'amount' => 100.00,
+            'date' => now()->toDateString(),
+            'is_indirect' => true,
+            'allocation_percentage' => 25.00,
+        ]);
+
+        $fresh = $expense->fresh();
+
+        $this->assertTrue($fresh->exists);
+        $this->assertTrue($fresh->is_indirect);
+        $this->assertSame('25.00', $fresh->allocation_percentage);
+        // getAllocatedAmount() reads both columns: 100 * (25 / 100)
+        $this->assertEqualsWithDelta(25.0, (float) $fresh->getAllocatedAmount(), 0.001);
+    }
+
+    public function test_budget_mass_assigns_honest_fillable_without_category(): void
+    {
+        $budget = Budget::factory()->create([
+            'description' => 'Q1 marketing',
+            'forecast_amount' => 5000,
+            'is_approved' => true,
+        ]);
+
+        $this->assertTrue($budget->fresh()->exists);
+        $this->assertNotContains('category', $budget->getFillable());
+    }
+}

--- a/tests/Feature/ModelSchemaConsistencyTest.php
+++ b/tests/Feature/ModelSchemaConsistencyTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Category;
+use App\Models\Invoice;
+use App\Models\PaymentTerm;
+use App\Models\SiteSettings;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ModelSchemaConsistencyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_invoice_notes_column_persists(): void
+    {
+        $invoice = Invoice::factory()->create(['notes' => 'Handle with care']);
+
+        $this->assertSame('Handle with care', $invoice->fresh()->notes);
+    }
+
+    public function test_category_parent_and_children_resolve(): void
+    {
+        $parent = Category::create(['name' => 'Assets']);
+        $child = Category::create(['name' => 'Current Assets', 'parent_id' => $parent->id]);
+
+        $this->assertTrue($parent->children->contains($child));
+        $this->assertTrue($child->parent->is($parent));
+    }
+
+    public function test_payment_term_number_of_days_persists(): void
+    {
+        $term = PaymentTerm::create([
+            'payment_term_name' => 'Net 30',
+            'payment_term_description' => 'Due in 30 days',
+            'payment_term_number_of_days' => 30,
+        ]);
+
+        $this->assertSame(30, (int) $term->fresh()->payment_term_number_of_days);
+    }
+
+    public function test_site_settings_resolves_real_table(): void
+    {
+        // Neither call should hit a missing-table error.
+        SiteSettings::first();
+        $this->assertSame('settings', (new SiteSettings)->getTable());
+        $this->assertGreaterThanOrEqual(0, SiteSettings::query()->count());
+    }
+}

--- a/tests/Feature/ProjectResurrectionTest.php
+++ b/tests/Feature/ProjectResurrectionTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Expense;
+use App\Models\Project;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Guards the resurrected Project feature: the projects table must exist and
+ * match Project::$fillable (mass-assignment), and the project_id FK on related
+ * tables must let the belongsTo/hasMany relations resolve in both directions.
+ */
+class ProjectResurrectionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_project_mass_assign_matches_fillable_schema(): void
+    {
+        // Every $fillable key — proves the table has a column for each.
+        $project = Project::create([
+            'name' => 'Apollo',
+            'code' => 'PRJ-001',
+            'description' => 'Moon shot',
+            'start_date' => '2026-01-01',
+            'end_date' => '2026-12-31',
+            'status' => 'active',
+            'allocation_percentage' => 42.50,
+        ]);
+
+        $this->assertTrue($project->exists);
+        $this->assertDatabaseHas('projects', ['code' => 'PRJ-001', 'name' => 'Apollo']);
+        $this->assertSame('42.50', (string) $project->fresh()->allocation_percentage);
+    }
+
+    public function test_project_factory_creates(): void
+    {
+        $this->assertTrue(Project::factory()->create()->exists);
+    }
+
+    public function test_project_expense_relations_resolve_both_directions(): void
+    {
+        $project = Project::factory()->create();
+
+        $expense = Expense::create([
+            'user_id' => User::factory()->create()->id,
+            'description' => 'materials',
+            'amount' => 100.00,
+            'date' => now()->toDateString(),
+            'project_id' => $project->id,
+        ]);
+
+        // belongsTo: Expense -> Project
+        $this->assertTrue($expense->project->is($project));
+
+        // hasMany: Project -> Expense
+        $this->assertTrue($project->expenses()->whereKey($expense->id)->exists());
+    }
+}


### PR DESCRIPTION
Cross-checked **every model's `$fillable` against the real migrated MySQL schema** (`getColumnListing`) — mass-assigning a column that doesn't exist errors on MySQL but is silently dropped by the SQLite test suite (same masking class as #838/#839). Found 7 mismatches + a table-less feature. Each resolved by the rule **wired → add the column; dead → remove from fillable**. **SQLite 449 + MySQL 449 pass (0 failures), PHPStan `[OK]`.**

### Resurrected: Projects feature (was 500-in-prod)
`Project` had **no `projects` table** yet was wired into `ProjectReportService`, `TimeEntryResource`, and `project_id` on Budget/Expense — so any project query/select 500'd in production (CLAUDE.md lists it as shipped; the table was lost). Added the `projects` table (schema derived from `Project::$fillable` + `team_id`), `project_id` FKs on budgets/expenses/estimates/invoices/time_entries/**transactions** (`Project::transactions()` + `Budget::getActualAmount()` need it), a factory, and a relation test.

### Wired → column added
- **Invoice `notes`** — used by `InvoiceResource` (`Textarea`), the API validator, and the PDF blade. Added `notes` (also closes an earlier orphaned-PDF-field follow-up).
- **Category `parent_id`** — `parent()`/`children()` + `CategoryResource` select. Added self-FK. **Also fixed** a fictional `$primaryKey = 'category_id'` on Category (table uses `id`; every external FK constrains to `categories.id`) that broke the relations.
- **PaymentTerm `payment_term_number_of_days`** — used in `PaymentTermResource`. Added integer column.
- **Expense `is_indirect` / `allocation_percentage`** — read by `ProjectReportService::calculateIndirectCosts()` + `Expense::getAllocatedAmount()`. Added columns.

### Dead → removed from fillable
- **Budget `category`** — zero consumers (no field, service, factory, or test).

### SiteSettings — partial fix + flagged
Model resolved a non-existent `site_settings` table → set `$table = 'settings'` (the real table), stopping a hard 500 (it never worked before, so no regression). **Deeper issue flagged:** the migration named `create_site_settings_table` actually creates a Spatie-style k/v `settings` table (name/group/payload), but `SiteSettings::$fillable` is columnar (currency/address/social links) — they're unrelated. Needs a design call (own columnar table vs adopt Spatie settings vs drop the model). Out of scope here.

### Method
Complements #839's MySQL-suite run: that validated *tested* paths; this fillable-vs-schema scan catches the *untested* ones. Reinforces **P0-10 (add a MySQL CI job)** — these bugs are invisible to SQLite.