### PR TITLE
feat: consolidated / cross-company reporting (P1-6)

### DIFF
--- a/app/Filament/App/Pages/ConsolidatedReports.php
+++ b/app/Filament/App/Pages/ConsolidatedReports.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\App\Pages;
+
+use App\Models\ConsolidationGroup;
+use App\Services\ConsolidationService;
+use Carbon\Carbon;
+use Filament\Actions\Action;
+use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\Select;
+use Filament\Pages\Page;
+use Filament\Schemas\Components\Actions;
+use Filament\Schemas\Components\EmbeddedSchema;
+use Filament\Schemas\Components\Group;
+use Filament\Schemas\Schema;
+use Illuminate\Support\Facades\Auth;
+
+/**
+ * Group-level consolidated financial statements. Pick a consolidation group +
+ * period and see combined / eliminations / consolidated P&L, balance sheet, and
+ * cash flow. A user only sees groups that include a team they belong to.
+ */
+class ConsolidatedReports extends Page
+{
+    #[\Override]
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-building-office-2';
+
+    #[\Override]
+    protected static ?string $title = 'Consolidated Reports';
+
+    #[\Override]
+    protected string $view = 'filament.app.pages.consolidated-reports';
+
+    /** @var array<string, mixed>|null */
+    public ?array $data = [];
+
+    /** @var array<string, mixed>|null */
+    public ?array $profitAndLoss = null;
+
+    /** @var array<string, mixed>|null */
+    public ?array $balanceSheet = null;
+
+    /** @var array<string, mixed>|null */
+    public ?array $cashFlow = null;
+
+    public function mount(): void
+    {
+        $this->form->fill([
+            'start_date' => now()->startOfYear()->toDateString(),
+            'end_date' => now()->endOfYear()->toDateString(),
+        ]);
+    }
+
+    /**
+     * Groups the current user may view: those including a team the user belongs to.
+     *
+     * @return array<int, string>
+     */
+    public function visibleGroups(): array
+    {
+        $teamIds = Auth::user()?->allTeams()->pluck('id')->all() ?? [];
+
+        return ConsolidationGroup::whereHas('members', fn ($q) => $q->whereIn('teams.id', $teamIds))
+            ->pluck('name', 'id')
+            ->all();
+    }
+
+    public function form(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Select::make('consolidation_group_id')
+                    ->label('Consolidation group')
+                    ->options(fn (): array => $this->visibleGroups())
+                    ->required(),
+                DatePicker::make('start_date')->required(),
+                DatePicker::make('end_date')->required(),
+            ])
+            ->statePath('data');
+    }
+
+    public function content(Schema $schema): Schema
+    {
+        return $schema->components([
+            Group::make([
+                EmbeddedSchema::make('form'),
+                Actions::make([
+                    Action::make('generate')
+                        ->label('Generate')
+                        ->action(fn () => $this->generate()),
+                ]),
+            ]),
+        ]);
+    }
+
+    public function generate(): void
+    {
+        $data = $this->data ?? [];
+        $groupId = (int) ($data['consolidation_group_id'] ?? 0);
+
+        // Only produce a report for a group the user may actually see.
+        if (! array_key_exists($groupId, $this->visibleGroups())) {
+            return;
+        }
+
+        $group = ConsolidationGroup::findOrFail($groupId);
+        $start = Carbon::parse($data['start_date']);
+        $end = Carbon::parse($data['end_date']);
+
+        $service = app(ConsolidationService::class);
+        $this->profitAndLoss = $service->consolidatedProfitAndLoss($group, $start, $end);
+        $this->balanceSheet = $service->consolidatedBalanceSheet($group, $end);
+        $this->cashFlow = $service->consolidatedCashFlow($group, $start, $end);
+    }
+}

--- a/app/Filament/App/Resources/ConsolidationGroups/ConsolidationGroupResource.php
+++ b/app/Filament/App/Resources/ConsolidationGroups/ConsolidationGroupResource.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\App\Resources\ConsolidationGroups;
+
+use App\Filament\App\Resources\ConsolidationGroups\Pages\CreateConsolidationGroup;
+use App\Filament\App\Resources\ConsolidationGroups\Pages\EditConsolidationGroup;
+use App\Filament\App\Resources\ConsolidationGroups\Pages\ListConsolidationGroups;
+use App\Models\ConsolidationGroup;
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Facades\Filament;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Auth;
+
+class ConsolidationGroupResource extends Resource
+{
+    #[\Override]
+    protected static ?string $model = ConsolidationGroup::class;
+
+    // ConsolidationGroup has an ownerTeam() relation, not the `team()` Filament's
+    // auto tenant scope expects — scope + stamp owner_team_id manually instead.
+    protected static bool $isScopedToTenant = false;
+
+    #[\Override]
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-building-office-2';
+
+    #[\Override]
+    protected static ?string $navigationLabel = 'Consolidation Groups';
+
+    #[\Override]
+    public static function getEloquentQuery(): Builder
+    {
+        // A team only manages the groups it owns.
+        return parent::getEloquentQuery()->where('owner_team_id', Filament::getTenant()?->getKey());
+    }
+
+    /**
+     * Team ids the acting user may add as members — the teams they belong to.
+     * Used both to filter the form options and to enforce membership server-side
+     * (Filament does not re-validate submitted relationship ids against options).
+     *
+     * @return array<int, int>
+     */
+    public static function allowedTeamIds(): array
+    {
+        return Auth::user()?->allTeams()->pluck('id')->map(fn ($v): int => (int) $v)->all() ?? [];
+    }
+
+    /**
+     * Drop any attached member team the acting user is not entitled to add.
+     * Called after create/save so a crafted request can't attach foreign teams
+     * (option-filtering alone is not enforced by Filament on submit).
+     */
+    public static function enforceAllowedMembers(ConsolidationGroup $group): void
+    {
+        $allowed = self::allowedTeamIds();
+        $keep = $group->members()->pluck('teams.id')->map(fn ($v): int => (int) $v)->intersect($allowed)->all();
+        $group->members()->sync($keep);
+    }
+
+    #[\Override]
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->components([
+            TextInput::make('name')->required(),
+            Select::make('members')
+                ->label('Member teams')
+                // Only teams the user belongs to are selectable — a group must
+                // not be able to pull in (and later disclose) another tenant's books.
+                ->relationship('members', 'name', modifyQueryUsing: fn (Builder $query): Builder => $query->whereIn('teams.id', self::allowedTeamIds()))
+                ->multiple()
+                ->preload()
+                ->required(),
+        ]);
+    }
+
+    #[\Override]
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('name')->searchable()->sortable(),
+                TextColumn::make('members_count')->counts('members')->label('Members'),
+            ])
+            ->recordActions([
+                EditAction::make(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    #[\Override]
+    public static function getRelations(): array
+    {
+        return [];
+    }
+
+    #[\Override]
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListConsolidationGroups::route('/'),
+            'create' => CreateConsolidationGroup::route('/create'),
+            'edit' => EditConsolidationGroup::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/App/Resources/ConsolidationGroups/Pages/CreateConsolidationGroup.php
+++ b/app/Filament/App/Resources/ConsolidationGroups/Pages/CreateConsolidationGroup.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\App\Resources\ConsolidationGroups\Pages;
+
+use App\Filament\App\Resources\ConsolidationGroups\ConsolidationGroupResource;
+use Filament\Facades\Filament;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateConsolidationGroup extends CreateRecord
+{
+    #[\Override]
+    protected static string $resource = ConsolidationGroupResource::class;
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    #[\Override]
+    protected function mutateFormDataBeforeCreate(array $data): array
+    {
+        // The current tenant team owns the group.
+        $data['owner_team_id'] = Filament::getTenant()?->getKey();
+
+        return $data;
+    }
+
+    protected function afterCreate(): void
+    {
+        ConsolidationGroupResource::enforceAllowedMembers($this->record);
+    }
+}

--- a/app/Filament/App/Resources/ConsolidationGroups/Pages/EditConsolidationGroup.php
+++ b/app/Filament/App/Resources/ConsolidationGroups/Pages/EditConsolidationGroup.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\App\Resources\ConsolidationGroups\Pages;
+
+use App\Filament\App\Resources\ConsolidationGroups\ConsolidationGroupResource;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+
+class EditConsolidationGroup extends EditRecord
+{
+    #[\Override]
+    protected static string $resource = ConsolidationGroupResource::class;
+
+    #[\Override]
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+        ];
+    }
+
+    protected function afterSave(): void
+    {
+        ConsolidationGroupResource::enforceAllowedMembers($this->record);
+    }
+}

--- a/app/Filament/App/Resources/ConsolidationGroups/Pages/ListConsolidationGroups.php
+++ b/app/Filament/App/Resources/ConsolidationGroups/Pages/ListConsolidationGroups.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\App\Resources\ConsolidationGroups\Pages;
+
+use App\Filament\App\Resources\ConsolidationGroups\ConsolidationGroupResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListConsolidationGroups extends ListRecords
+{
+    #[\Override]
+    protected static string $resource = ConsolidationGroupResource::class;
+
+    #[\Override]
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Models/ConsolidationGroup.php
+++ b/app/Models/ConsolidationGroup.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class ConsolidationGroup extends Model
+{
+    #[\Override]
+    protected $fillable = [
+        'name',
+        'owner_team_id',
+    ];
+
+    public function ownerTeam(): BelongsTo
+    {
+        return $this->belongsTo(Team::class, 'owner_team_id');
+    }
+
+    /**
+     * @return BelongsToMany<Team, $this>
+     */
+    public function members(): BelongsToMany
+    {
+        return $this->belongsToMany(Team::class, 'consolidation_group_team');
+    }
+}

--- a/app/Models/JournalEntry.php
+++ b/app/Models/JournalEntry.php
@@ -23,6 +23,7 @@ class JournalEntry extends Model
         'reference_number',
         'memo',
         'entry_type',
+        'counterparty_team_id',
         'approval_status',
         'rejection_reason',
     ];
@@ -94,6 +95,11 @@ class JournalEntry extends Model
     public function lines()
     {
         return $this->hasMany(JournalEntryLine::class);
+    }
+
+    public function counterpartyTeam()
+    {
+        return $this->belongsTo(Team::class, 'counterparty_team_id');
     }
 
     public function approvalAmount(): float

--- a/app/Services/ConsolidationService.php
+++ b/app/Services/ConsolidationService.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\ConsolidationGroup;
+use App\Models\JournalEntryLine;
+use Carbon\Carbon;
+
+/**
+ * Group-level financial statements: aggregate each member team's statement,
+ * then net out intercompany amounts (P&L + balance sheet) so a group doesn't
+ * double-count sales/loans between its own members.
+ *
+ * Cash flow consolidates by simple sum this increment (no cash-flow-specific
+ * eliminations — see the design spec).
+ */
+class ConsolidationService
+{
+    /** Balance-sheet asset account types (mirror FinancialStatementService). */
+    private const ASSET_TYPES = ['asset', 'bank', 'current_asset', 'fixed_asset', 'other_asset'];
+
+    /** Balance-sheet liability account types. */
+    private const LIABILITY_TYPES = ['liability', 'current_liability', 'long_term_liability'];
+
+    /** Account types whose normal balance is a debit (mirror getAccountBalance). */
+    private const DEBIT_NORMAL = ['asset', 'expense', 'bank', 'current_asset', 'fixed_asset', 'other_asset', 'cost_of_goods_sold'];
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function consolidatedProfitAndLoss(ConsolidationGroup $group, Carbon $start, Carbon $end): array
+    {
+        $memberIds = $this->memberIds($group);
+        $members = [];
+        $combined = ['revenue' => 0.0, 'cost_of_goods_sold' => 0.0, 'gross_profit' => 0.0, 'expenses' => 0.0, 'net_income' => 0.0];
+
+        foreach ($memberIds as $id) {
+            $pl = $this->statements()->withTeam($id)->profitAndLoss($start, $end);
+            $members[] = ['team_id' => $id, 'statement' => $pl];
+            $combined['revenue'] += (float) $pl['revenue']['total'];
+            $combined['cost_of_goods_sold'] += (float) $pl['cost_of_goods_sold']['total'];
+            $combined['expenses'] += (float) $pl['expenses']['total'];
+            $combined['gross_profit'] += (float) $pl['gross_profit'];
+            $combined['net_income'] += (float) $pl['net_income'];
+        }
+
+        $eliminations = [
+            'revenue' => $this->intercompanyBalance($memberIds, ['revenue'], $start, $end),
+            'cost_of_goods_sold' => $this->intercompanyBalance($memberIds, ['cost_of_goods_sold'], $start, $end),
+            'expenses' => $this->intercompanyBalance($memberIds, ['expense'], $start, $end),
+        ];
+
+        $revenue = $combined['revenue'] - $eliminations['revenue'];
+        $cogs = $combined['cost_of_goods_sold'] - $eliminations['cost_of_goods_sold'];
+        $expenses = $combined['expenses'] - $eliminations['expenses'];
+        $grossProfit = $revenue - $cogs;
+
+        return [
+            'period' => ['start_date' => $start->toDateString(), 'end_date' => $end->toDateString()],
+            'members' => $members,
+            'combined' => $combined,
+            'eliminations' => $eliminations,
+            'consolidated' => [
+                'revenue' => $revenue,
+                'cost_of_goods_sold' => $cogs,
+                'gross_profit' => $grossProfit,
+                'expenses' => $expenses,
+                'net_income' => $grossProfit - $expenses,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function consolidatedBalanceSheet(ConsolidationGroup $group, Carbon $asOf): array
+    {
+        $memberIds = $this->memberIds($group);
+        $members = [];
+        $combined = ['assets' => 0.0, 'liabilities' => 0.0, 'equity' => 0.0];
+
+        foreach ($memberIds as $id) {
+            $bs = $this->statements()->withTeam($id)->balanceSheet($asOf);
+            $members[] = ['team_id' => $id, 'statement' => $bs];
+            $combined['assets'] += (float) $bs['assets']['total'];
+            $combined['liabilities'] += (float) $bs['liabilities']['total'];
+            $combined['equity'] += (float) $bs['equity']['total'];
+        }
+
+        $eliminations = [
+            'assets' => $this->intercompanyBalance($memberIds, self::ASSET_TYPES, null, $asOf),
+            'liabilities' => $this->intercompanyBalance($memberIds, self::LIABILITY_TYPES, null, $asOf),
+        ];
+
+        $assets = $combined['assets'] - $eliminations['assets'];
+        $liabilities = $combined['liabilities'] - $eliminations['liabilities'];
+        $equity = $combined['equity'];
+
+        return [
+            'as_of_date' => $asOf->toDateString(),
+            'members' => $members,
+            'combined' => $combined,
+            'eliminations' => $eliminations,
+            'consolidated' => [
+                'assets' => $assets,
+                'liabilities' => $liabilities,
+                'equity' => $equity,
+                'total_liabilities_and_equity' => $liabilities + $equity,
+            ],
+        ];
+    }
+
+    /**
+     * Cash flow: simple sum across members, no eliminations this increment.
+     *
+     * @return array<string, mixed>
+     */
+    public function consolidatedCashFlow(ConsolidationGroup $group, Carbon $start, Carbon $end): array
+    {
+        $memberIds = $this->memberIds($group);
+        $members = [];
+        $combined = ['operating' => 0.0, 'investing' => 0.0, 'financing' => 0.0, 'net_change_in_cash' => 0.0, 'beginning_cash' => 0.0, 'ending_cash' => 0.0];
+
+        foreach ($memberIds as $id) {
+            $cf = $this->statements()->withTeam($id)->cashFlowStatement($start, $end);
+            $members[] = ['team_id' => $id, 'statement' => $cf];
+            $combined['operating'] += (float) $cf['operating_activities']['net_cash_from_operations'];
+            $combined['investing'] += (float) $cf['investing_activities']['net_cash_from_investing'];
+            $combined['financing'] += (float) $cf['financing_activities']['net_cash_from_financing'];
+            $combined['net_change_in_cash'] += (float) $cf['net_change_in_cash'];
+            $combined['beginning_cash'] += (float) $cf['beginning_cash'];
+            $combined['ending_cash'] += (float) $cf['ending_cash'];
+        }
+
+        return [
+            'period' => ['start_date' => $start->toDateString(), 'end_date' => $end->toDateString()],
+            'members' => $members,
+            'combined' => $combined,
+            'eliminations' => ['operating' => 0.0, 'investing' => 0.0, 'financing' => 0.0],
+            'consolidated' => $combined,
+        ];
+    }
+
+    /**
+     * Signed, normal-balance sum of posted intercompany lines: lines on a member
+     * account of one of $accountTypes whose entry is tagged with a fellow-member
+     * counterparty. This is exactly the portion of the combined totals that is
+     * internal to the group, so subtracting it removes the double-count.
+     *
+     * @param  array<int, int>  $memberIds
+     * @param  array<int, string>  $accountTypes
+     */
+    private function intercompanyBalance(array $memberIds, array $accountTypes, ?Carbon $start, Carbon $end): float
+    {
+        if ($memberIds === []) {
+            return 0.0;
+        }
+
+        $lines = JournalEntryLine::query()
+            ->whereHas('journalEntry', function ($q) use ($memberIds, $start, $end): void {
+                $q->where('is_posted', true)
+                    ->whereIn('counterparty_team_id', $memberIds)
+                    ->where('entry_date', '<=', $end);
+                if ($start instanceof Carbon) {
+                    $q->where('entry_date', '>=', $start);
+                }
+            })
+            ->whereHas('account', fn ($q) => $q->whereIn('team_id', $memberIds)->whereIn('account_type', $accountTypes))
+            ->with('account')
+            ->get();
+
+        $total = 0.0;
+        foreach ($lines as $line) {
+            $debitNormal = in_array($line->account->account_type, self::DEBIT_NORMAL, true);
+            $total += $debitNormal
+                ? (float) $line->debit_amount - (float) $line->credit_amount
+                : (float) $line->credit_amount - (float) $line->debit_amount;
+        }
+
+        return $total;
+    }
+
+    /**
+     * @return array<int, int>
+     */
+    private function memberIds(ConsolidationGroup $group): array
+    {
+        return $group->members()->pluck('teams.id')->map(fn ($v): int => (int) $v)->all();
+    }
+
+    private function statements(): FinancialStatementService
+    {
+        return app(FinancialStatementService::class);
+    }
+}

--- a/app/Services/ConsolidationService.php
+++ b/app/Services/ConsolidationService.php
@@ -15,11 +15,25 @@ use Carbon\Carbon;
  *
  * Cash flow consolidates by simple sum this increment (no cash-flow-specific
  * eliminations — see the design spec).
+ *
+ * CONSTRAINT (until the deferred intercompany-entry authoring UI lands): an
+ * intercompany entry is assumed to carry a single in-scope receivable/payable
+ * line per side (A/R on the seller, A/P on the buyer). Elimination sums every
+ * tagged line of the eliminable types, so a cash-SETTLED or multi-line
+ * intercompany entry would over-eliminate. Cash/bank is therefore deliberately
+ * excluded from eliminable assets below — an intercompany balance is a
+ * receivable/payable, never cash — which defuses the settlement footgun.
  */
 class ConsolidationService
 {
-    /** Balance-sheet asset account types (mirror FinancialStatementService). */
-    private const ASSET_TYPES = ['asset', 'bank', 'current_asset', 'fixed_asset', 'other_asset'];
+    /**
+     * Asset types eligible for intercompany elimination — the balance-sheet
+     * asset types minus cash/bank. Intercompany balances are receivables, not
+     * cash, so a cash settlement line on a tagged entry must not be swept into
+     * eliminations. (Combined asset totals come from FinancialStatementService,
+     * which keeps its own full asset-type list.)
+     */
+    private const ELIMINABLE_ASSET_TYPES = ['asset', 'current_asset', 'fixed_asset', 'other_asset'];
 
     /** Balance-sheet liability account types. */
     private const LIABILITY_TYPES = ['liability', 'current_liability', 'long_term_liability'];
@@ -90,7 +104,7 @@ class ConsolidationService
         }
 
         $eliminations = [
-            'assets' => $this->intercompanyBalance($memberIds, self::ASSET_TYPES, null, $asOf),
+            'assets' => $this->intercompanyBalance($memberIds, self::ELIMINABLE_ASSET_TYPES, null, $asOf),
             'liabilities' => $this->intercompanyBalance($memberIds, self::LIABILITY_TYPES, null, $asOf),
         ];
 

--- a/app/Services/FinancialStatementService.php
+++ b/app/Services/FinancialStatementService.php
@@ -12,16 +12,37 @@ use Illuminate\Support\Collection;
 class FinancialStatementService
 {
     /**
-     * The acting user's current team, or -1 when there is none — a sentinel that
-     * matches no row (team ids are positive), so a tenantless call returns empty
-     * rather than leaking every unassigned (team_id IS NULL) row.
+     * When set, statements are produced for this team instead of the acting
+     * user's current team. Lets consolidation compute any member team without
+     * an auth context (see withTeam()).
+     */
+    private ?int $teamOverride = null;
+
+    /**
+     * An immutable copy scoped to a specific team. Every statement method
+     * resolves its team through scopedTeamId(), so this reparameterizes all of
+     * them without threading a team id through each call.
+     */
+    public function withTeam(int $teamId): self
+    {
+        $clone = clone $this;
+        $clone->teamOverride = $teamId;
+
+        return $clone;
+    }
+
+    /**
+     * The team to scope to: an explicit override, else the acting user's
+     * current team, else -1 — a sentinel that matches no row (team ids are
+     * positive), so a tenantless call returns empty rather than leaking every
+     * unassigned (team_id IS NULL) row.
      *
      * Mirrors GeneralLedgerService::scopedTeamId(); statements are only produced
-     * in authenticated contexts (Sanctum API, Filament panel).
+     * in authenticated contexts (Sanctum API, Filament panel) or via withTeam().
      */
     private function scopedTeamId(): int
     {
-        return auth()->user()->current_team_id ?? -1;
+        return $this->teamOverride ?? auth()->user()?->current_team_id ?? -1;
     }
 
     /**

--- a/database/migrations/2026_07_04_110001_create_consolidation_groups_table.php
+++ b/database/migrations/2026_07_04_110001_create_consolidation_groups_table.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('consolidation_groups', function (Blueprint $table): void {
+            $table->id();
+            $table->string('name');
+            $table->foreignId('owner_team_id')->constrained('teams')->cascadeOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('consolidation_groups');
+    }
+};

--- a/database/migrations/2026_07_04_110002_create_consolidation_group_team_table.php
+++ b/database/migrations/2026_07_04_110002_create_consolidation_group_team_table.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('consolidation_group_team', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('consolidation_group_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('team_id')->constrained('teams')->cascadeOnDelete();
+            $table->timestamps();
+            $table->unique(['consolidation_group_id', 'team_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('consolidation_group_team');
+    }
+};

--- a/database/migrations/2026_07_04_110003_add_counterparty_team_id_to_journal_entries_table.php
+++ b/database/migrations/2026_07_04_110003_add_counterparty_team_id_to_journal_entries_table.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+// Tags a journal entry as intercompany: the other member team it transacts with.
+// Consolidated statements net out amounts on entries whose counterparty is a
+// fellow group member, so the group isn't double-counted.
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('journal_entries', function (Blueprint $table): void {
+            $table->foreignId('counterparty_team_id')->nullable()->after('entry_type')
+                ->constrained('teams')->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('journal_entries', function (Blueprint $table): void {
+            $table->dropConstrainedForeignId('counterparty_team_id');
+        });
+    }
+};

--- a/docs/superpowers/specs/2026-07-04-consolidated-reporting-design.md
+++ b/docs/superpowers/specs/2026-07-04-consolidated-reporting-design.md
@@ -1,0 +1,122 @@
+# Consolidated / Cross-Company Reporting — Design
+
+**Status:** approved (design) · **Date:** 2026-07-04 · **Backlog:** P1-6
+
+## Problem
+
+`FinancialStatementService` produces a P&L, balance sheet, and cash-flow statement for **one** team — every query scopes to `auth()->user()->current_team_id` (via the private `scopedTeamId()`, and team ownership flows through `Account.team_id`, since `journal_entries` has no `team_id`). There is no way to group teams and produce a combined, group-level statement across tenants.
+
+## Decisions (locked)
+
+- **Grouping:** a `ConsolidationGroup` entity; teams attach via a `group_team` pivot (`members()` belongsToMany). A team may belong to several groups.
+- **Method:** aggregate member statements **and eliminate intercompany** amounts (so the group isn't double-counted).
+- **Statements:** P&L + balance sheet + cash flow.
+- **Access:** any member of any member team may **view**; managing a group's membership is limited to members of its `owner_team`.
+
+## Scope boundaries (approved)
+
+- **Eliminations apply to P&L + balance sheet.** **Cash flow consolidates by simple sum** this increment (cash-flow-specific eliminations deferred, documented).
+- Ships the elimination **engine + tag column + tests** (entries are tagged directly). A Filament flow to *author* an intercompany entry (mark counterparty on entry creation) is a **follow-up** — out of scope here.
+- Single currency assumed (no per-team base currency exists). FX normalization out of scope.
+
+## Architecture
+
+### 1. Grouping (`ConsolidationGroup`)
+
+- Migration `consolidation_groups`: `id`, `name`, `owner_team_id` (FK teams), timestamps.
+- Migration `group_team` pivot: `consolidation_group_id`, `team_id`, unique together.
+- Model: `members(): BelongsToMany<Team>`, `ownerTeam(): BelongsTo<Team>`.
+- Filament `ConsolidationGroupResource` (app panel): create/rename a group, attach/detach member teams (a multi-select of teams the user can see). Membership management gated to `owner_team` members.
+
+### 2. Reparameterize `FinancialStatementService` (targeted, backward-compatible)
+
+Add an immutable team override so consolidation can compute any member without auth context:
+
+```php
+private ?int $teamOverride = null;
+
+public function withTeam(int $teamId): self
+{
+    $clone = clone $this;
+    $clone->teamOverride = $teamId;
+    return $clone;
+}
+
+private function scopedTeamId(): int
+{
+    return $this->teamOverride ?? auth()->user()?->current_team_id ?? -1;
+}
+```
+
+Every statement method + helper already resolves team through `scopedTeamId()`, so this one change reparameterizes all of them. Default behavior (no override) is unchanged — existing callers and tests are unaffected.
+
+### 3. Intercompany tag
+
+- Migration: add nullable `counterparty_team_id` (FK teams, `nullOnDelete`) to `journal_entries`. Marks an entry as intercompany with the other party team.
+- `JournalEntry`: add to `$fillable` + `counterpartyTeam(): BelongsTo<Team>`.
+- (Populating it is the deferred authoring UI; here it's set directly, incl. in tests.)
+
+### 4. `ConsolidationService` (new)
+
+`consolidatedProfitAndLoss(ConsolidationGroup $g, Carbon $start, Carbon $end): array`,
+`consolidatedBalanceSheet(ConsolidationGroup $g, Carbon $asOf): array`,
+`consolidatedCashFlow(ConsolidationGroup $g, Carbon $start, Carbon $end): array`.
+
+Each:
+1. `$members = $g->members` (team ids).
+2. For each member: `app(FinancialStatementService::class)->withTeam($id)->{statement}(...)` → per-member result.
+3. **Aggregate** line-category totals across members (sum revenue, expense, assets, liabilities, equity, cash sections…).
+4. **Eliminate** (P&L + BS only) via `intercompanyTotals($members, …)` and subtract.
+
+Output shape per statement:
+```
+[ 'members' => [ ['team_id'=>.., 'statement'=>..], .. ],
+  'combined' => <line-category totals, summed>,
+  'eliminations' => <intercompany amounts removed>,   // zero-filled for cash flow
+  'consolidated' => combined − eliminations ]
+```
+
+### 5. Eliminations engine
+
+`intercompanyTotals(array $memberIds, Carbon $start, ?Carbon $end, array $accountTypes): array` — sum **posted** `JournalEntryLine`s where:
+- the line's `journalEntry.counterparty_team_id` ∈ `$memberIds` (an intercompany entry between members), **and**
+- the line's `account.team_id` ∈ `$memberIds`, `account.account_type` ∈ `$accountTypes`,
+- within the date window (P&L) or as-of (BS),
+summed by each account's normal balance (mirrors `getAccountBalance`).
+
+- **P&L:** eliminate `revenue` and `expense`/`cost_of_goods_sold` categories → intercompany sales net against intercompany purchases.
+- **BS:** eliminate the **same asset and liability `account_type` lists `balanceSheet()` uses** (assets: `asset,bank,current_asset,fixed_asset,other_asset`; liabilities: `liability,current_liability,long_term_liability`) → intercompany receivables (assets) net against payables (liabilities). Accounts carry no dedicated receivable/payable type, so intercompany identity comes solely from the entry's `counterparty_team_id` tag, not the account type.
+
+### 6. UI — `ConsolidatedReports` Filament page (app panel)
+
+Pick a group (the user can see) + period → renders the three consolidated statements (combined, eliminations, consolidated columns). View gated: user is a member of some team in the group.
+
+## Data flow
+
+Select group + period → `ConsolidationService` → per-member `FinancialStatementService->withTeam()` statements → line-category aggregation → subtract `intercompanyTotals()` (P&L/BS) → consolidated array → Filament page renders.
+
+## Error handling / edge cases
+
+- Empty group (no members) → zero-filled consolidated statement, no error.
+- A member team with no accounts → contributes zeros.
+- `counterparty_team_id` pointing outside the group → **not** eliminated (only intra-group counterparties net out) — correct.
+- Access: a user not in any member team cannot open the report or the group; membership edits limited to `owner_team`.
+
+## Testing (PHPUnit, sqlite `:memory:`; also under MySQL CI)
+
+1. **Aggregation:** 2-team group, each with revenue/expense/asset accounts + posted entries → consolidated P&L/BS/cash-flow equal the per-team sums.
+2. **P&L elimination:** team A posts an intercompany sale to team B (`counterparty_team_id = B`, revenue on A / expense on B). Consolidated revenue and expense **exclude** the intercompany amount; a non-intercompany sale is retained.
+3. **BS elimination:** intercompany receivable (A) / payable (B) tagged → netted out of consolidated assets/liabilities.
+4. **Cash flow = simple sum:** consolidated cash flow equals the member sum (no elimination applied), `eliminations` section zero.
+5. **withTeam isolation:** `FinancialStatementService->withTeam($x)` returns team x's statement regardless of the logged-in user; the default (no override) still uses `current_team_id`.
+6. **Access gate:** non-member cannot view; owner-team member can edit membership, a plain member team's user cannot.
+7. **Empty group / out-of-group counterparty** edge cases.
+
+## Files
+
+- **New:** `app/Models/ConsolidationGroup.php`, `app/Services/ConsolidationService.php`, `app/Filament/App/Resources/ConsolidationGroups/*` (resource), `app/Filament/App/Pages/ConsolidatedReports.php`, migrations (`consolidation_groups`, `group_team`, `add_counterparty_team_id_to_journal_entries`), `tests/Feature/Consolidation/*`.
+- **Changed:** `app/Services/FinancialStatementService.php` (withTeam override), `app/Models/JournalEntry.php` (fillable + relation).
+
+## Non-goals (YAGNI — later, on request)
+
+- Intercompany-entry authoring UI; cash-flow eliminations; multi-currency FX; minority interest / partial ownership; elimination of intercompany equity investments; saved/scheduled consolidated report exports.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -367,6 +367,36 @@ parameters:
 			path: app/Filament/Admin/Resources/Users/UserResource.php
 
 		-
+			message: '#^Access to an undefined property App\\Filament\\App\\Pages\\ConsolidatedReports\:\:\$form\.$#'
+			identifier: property.notFound
+			count: 1
+			path: app/Filament/App/Pages/ConsolidatedReports.php
+
+		-
+			message: '#^Cannot call method fill\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: app/Filament/App/Pages/ConsolidatedReports.php
+
+		-
+			message: '#^Cannot cast mixed to int\.$#'
+			identifier: cast.int
+			count: 1
+			path: app/Filament/App/Pages/ConsolidatedReports.php
+
+		-
+			message: '#^Method App\\Filament\\App\\Pages\\ConsolidatedReports\:\:visibleGroups\(\) should return array\<int, string\> but returns array\<mixed\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Filament/App/Pages/ConsolidatedReports.php
+
+		-
+			message: '#^Parameter \#1 \$time of static method Carbon\\Carbon\:\:parse\(\) expects Carbon\\Month\|Carbon\\WeekDay\|DateTimeInterface\|float\|int\|string\|null, mixed given\.$#'
+			identifier: argument.type
+			count: 2
+			path: app/Filament/App/Pages/ConsolidatedReports.php
+
+		-
 			message: '#^Method App\\Filament\\App\\Pages\\CreateTeam\:\:getBreadcrumbs\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -749,6 +779,30 @@ parameters:
 			identifier: binaryOp.invalid
 			count: 1
 			path: app/Filament/App/Resources/ChartOfAccounts/Pages/ListChartOfAccounts.php
+
+		-
+			message: '#^Cannot cast mixed to int\.$#'
+			identifier: cast.int
+			count: 2
+			path: app/Filament/App/Resources/ConsolidationGroups/ConsolidationGroupResource.php
+
+		-
+			message: '#^Method App\\Filament\\App\\Resources\\ConsolidationGroups\\ConsolidationGroupResource\:\:allowedTeamIds\(\) should return array\<int, int\> but returns array\<int\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Filament/App/Resources/ConsolidationGroups/ConsolidationGroupResource.php
+
+		-
+			message: '#^Parameter \#1 \$group of static method App\\Filament\\App\\Resources\\ConsolidationGroups\\ConsolidationGroupResource\:\:enforceAllowedMembers\(\) expects App\\Models\\ConsolidationGroup, Illuminate\\Database\\Eloquent\\Model\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Filament/App/Resources/ConsolidationGroups/Pages/CreateConsolidationGroup.php
+
+		-
+			message: '#^Parameter \#1 \$group of static method App\\Filament\\App\\Resources\\ConsolidationGroups\\ConsolidationGroupResource\:\:enforceAllowedMembers\(\) expects App\\Models\\ConsolidationGroup, Illuminate\\Database\\Eloquent\\Model\|int\|string\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Filament/App/Resources/ConsolidationGroups/Pages/EditConsolidationGroup.php
 
 		-
 			message: '#^Cannot access property \$amount_remaining on mixed\.$#'
@@ -3499,6 +3553,12 @@ parameters:
 			path: app/Models/ConnectedAccount.php
 
 		-
+			message: '#^Method App\\Models\\ConsolidationGroup\:\:ownerTeam\(\) return type with generic class Illuminate\\Database\\Eloquent\\Relations\\BelongsTo does not specify its types\: TRelatedModel, TDeclaringModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/ConsolidationGroup.php
+
+		-
 			message: '#^Access to an undefined property App\\Models\\CreditMemo\:\:\$items\.$#'
 			identifier: property.notFound
 			count: 1
@@ -5030,6 +5090,12 @@ parameters:
 
 		-
 			message: '#^Method App\\Models\\JournalEntry\:\:approvedBy\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Models/JournalEntry.php
+
+		-
+			message: '#^Method App\\Models\\JournalEntry\:\:counterpartyTeam\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: app/Models/JournalEntry.php
@@ -7375,12 +7441,6 @@ parameters:
 			path: app/Notifications/PaymentReminderNotification.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\Invoice\:\:\$invoice_id\.$#'
-			identifier: property.notFound
-			count: 3
-			path: app/Notifications/PaymentReminderNotification.php
-
-		-
 			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$database_enabled\.$#'
 			identifier: property.notFound
 			count: 1
@@ -7405,25 +7465,7 @@ parameters:
 			path: app/Notifications/PaymentReminderNotification.php
 
 		-
-			message: '#^Binary operation "\." between ''/invoices/'' and mixed results in an error\.$#'
-			identifier: binaryOp.invalid
-			count: 1
-			path: app/Notifications/PaymentReminderNotification.php
-
-		-
 			message: '#^Binary operation "\." between ''Hello '' and mixed results in an error\.$#'
-			identifier: binaryOp.invalid
-			count: 1
-			path: app/Notifications/PaymentReminderNotification.php
-
-		-
-			message: '#^Binary operation "\." between ''Payment Reminder \-…'' and mixed results in an error\.$#'
-			identifier: binaryOp.invalid
-			count: 1
-			path: app/Notifications/PaymentReminderNotification.php
-
-		-
-			message: '#^Binary operation "\." between ''This is a reminder…'' and mixed results in an error\.$#'
 			identifier: binaryOp.invalid
 			count: 1
 			path: app/Notifications/PaymentReminderNotification.php
@@ -8323,6 +8365,72 @@ parameters:
 			path: app/Services/CollectionService.php
 
 		-
+			message: '#^Access to an undefined property App\\Models\\JournalEntryLine\:\:\$account\.$#'
+			identifier: property.notFound
+			count: 1
+			path: app/Services/ConsolidationService.php
+
+		-
+			message: '#^Cannot access offset ''net_cash_from_financing'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: app/Services/ConsolidationService.php
+
+		-
+			message: '#^Cannot access offset ''net_cash_from_investing'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: app/Services/ConsolidationService.php
+
+		-
+			message: '#^Cannot access offset ''net_cash_from_operations'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: app/Services/ConsolidationService.php
+
+		-
+			message: '#^Cannot access offset ''total'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 6
+			path: app/Services/ConsolidationService.php
+
+		-
+			message: '#^Cannot access property \$account_type on mixed\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: app/Services/ConsolidationService.php
+
+		-
+			message: '#^Cannot cast mixed to float\.$#'
+			identifier: cast.double
+			count: 14
+			path: app/Services/ConsolidationService.php
+
+		-
+			message: '#^Cannot cast mixed to int\.$#'
+			identifier: cast.int
+			count: 1
+			path: app/Services/ConsolidationService.php
+
+		-
+			message: '#^Method App\\Services\\ConsolidationService\:\:memberIds\(\) should return array\<int, int\> but returns array\<int\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Services/ConsolidationService.php
+
+		-
+			message: '#^Relation ''account'' is not found in App\\Models\\JournalEntryLine model\.$#'
+			identifier: larastan.relationExistence
+			count: 2
+			path: app/Services/ConsolidationService.php
+
+		-
+			message: '#^Relation ''journalEntry'' is not found in App\\Models\\JournalEntryLine model\.$#'
+			identifier: larastan.relationExistence
+			count: 1
+			path: app/Services/ConsolidationService.php
+
+		-
 			message: '#^Access to an undefined property App\\Models\\ExchangeRate\:\:\$fromCurrency\.$#'
 			identifier: property.notFound
 			count: 1
@@ -8523,6 +8631,12 @@ parameters:
 		-
 			message: '#^Relation ''journalEntry'' is not found in App\\Models\\JournalEntryLine model\.$#'
 			identifier: larastan.relationExistence
+			count: 1
+			path: app/Services/FinancialStatementService.php
+
+		-
+			message: '#^Using nullsafe property access "\?\-\>current_team_id" on left side of \?\? is unnecessary\. Use \-\> instead\.$#'
+			identifier: nullsafe.neverNull
 			count: 1
 			path: app/Services/FinancialStatementService.php
 

--- a/resources/views/filament/app/pages/consolidated-reports.blade.php
+++ b/resources/views/filament/app/pages/consolidated-reports.blade.php
@@ -1,0 +1,33 @@
+<x-filament-panels::page>
+    {{ $this->content }}
+
+    @if ($profitAndLoss)
+        <x-filament::section heading="Profit & Loss (consolidated)">
+            <div class="grid grid-cols-2 gap-2">
+                <span>Revenue</span><span>{{ number_format($profitAndLoss['consolidated']['revenue'], 2) }}</span>
+                <span>Expenses</span><span>{{ number_format($profitAndLoss['consolidated']['expenses'], 2) }}</span>
+                <span>Intercompany eliminated (revenue)</span><span>{{ number_format($profitAndLoss['eliminations']['revenue'], 2) }}</span>
+                <span class="font-bold">Net income</span><span class="font-bold">{{ number_format($profitAndLoss['consolidated']['net_income'], 2) }}</span>
+            </div>
+        </x-filament::section>
+    @endif
+
+    @if ($balanceSheet)
+        <x-filament::section heading="Balance Sheet (consolidated)">
+            <div class="grid grid-cols-2 gap-2">
+                <span>Assets</span><span>{{ number_format($balanceSheet['consolidated']['assets'], 2) }}</span>
+                <span>Liabilities</span><span>{{ number_format($balanceSheet['consolidated']['liabilities'], 2) }}</span>
+                <span>Equity</span><span>{{ number_format($balanceSheet['consolidated']['equity'], 2) }}</span>
+            </div>
+        </x-filament::section>
+    @endif
+
+    @if ($cashFlow)
+        <x-filament::section heading="Cash Flow (consolidated, simple sum)">
+            <div class="grid grid-cols-2 gap-2">
+                <span>Net change in cash</span><span>{{ number_format($cashFlow['consolidated']['net_change_in_cash'], 2) }}</span>
+                <span>Ending cash</span><span>{{ number_format($cashFlow['consolidated']['ending_cash'], 2) }}</span>
+            </div>
+        </x-filament::section>
+    @endif
+</x-filament-panels::page>

--- a/tests/Feature/Consolidation/ConsolidatedReportsTest.php
+++ b/tests/Feature/Consolidation/ConsolidatedReportsTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Consolidation;
+
+use App\Filament\App\Pages\ConsolidatedReports;
+use App\Models\ConsolidationGroup;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ConsolidatedReportsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function team(User $owner): Team
+    {
+        return Team::forceCreate(['user_id' => $owner->id, 'name' => 'T', 'personal_team' => false]);
+    }
+
+    public function test_generate_populates_the_three_consolidated_statements(): void
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+        $a = $this->team($user);
+        $b = $this->team($user);
+
+        $group = ConsolidationGroup::create(['name' => 'G', 'owner_team_id' => $a->id]);
+        $group->members()->sync([$a->id, $b->id]);
+
+        $page = new ConsolidatedReports;
+        $page->data = ['consolidation_group_id' => $group->id, 'start_date' => '2026-01-01', 'end_date' => '2026-12-31'];
+        $page->generate();
+
+        $this->assertArrayHasKey('net_income', $page->profitAndLoss['consolidated']);
+        $this->assertArrayHasKey('assets', $page->balanceSheet['consolidated']);
+        $this->assertArrayHasKey('net_change_in_cash', $page->cashFlow['consolidated']);
+    }
+
+    public function test_group_visible_only_to_member_team_users(): void
+    {
+        $owner = User::factory()->create();
+        $stranger = User::factory()->create();
+        $a = $this->team($owner);
+
+        $group = ConsolidationGroup::create(['name' => 'G', 'owner_team_id' => $a->id]);
+        $group->members()->sync([$a->id]);
+
+        $this->actingAs($owner);
+        $this->assertArrayHasKey($group->id, (new ConsolidatedReports)->visibleGroups());
+
+        $this->actingAs($stranger);
+        $this->assertArrayNotHasKey($group->id, (new ConsolidatedReports)->visibleGroups());
+    }
+
+    public function test_generate_ignores_a_group_the_user_cannot_see(): void
+    {
+        $owner = User::factory()->create();
+        $stranger = User::factory()->create();
+        $a = $this->team($owner);
+        $group = ConsolidationGroup::create(['name' => 'G', 'owner_team_id' => $a->id]);
+        $group->members()->sync([$a->id]);
+
+        $this->actingAs($stranger);
+        $page = new ConsolidatedReports;
+        $page->data = ['consolidation_group_id' => $group->id, 'start_date' => '2026-01-01', 'end_date' => '2026-12-31'];
+        $page->generate();
+
+        $this->assertNull($page->profitAndLoss);
+    }
+}

--- a/tests/Feature/Consolidation/ConsolidationGroupResourceTest.php
+++ b/tests/Feature/Consolidation/ConsolidationGroupResourceTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Consolidation;
+
+use App\Filament\App\Resources\ConsolidationGroups\ConsolidationGroupResource;
+use App\Models\ConsolidationGroup;
+use App\Models\Team;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ConsolidationGroupResourceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function team(User $owner, string $name): Team
+    {
+        return Team::forceCreate(['user_id' => $owner->id, 'name' => $name, 'personal_team' => false]);
+    }
+
+    public function test_query_is_scoped_to_the_current_tenant_owner_team(): void
+    {
+        $user = User::factory()->create();
+        $teamA = $this->team($user, 'A');
+        $teamB = $this->team($user, 'B');
+
+        $ownedByA = ConsolidationGroup::create(['name' => 'GA', 'owner_team_id' => $teamA->id]);
+        $ownedByB = ConsolidationGroup::create(['name' => 'GB', 'owner_team_id' => $teamB->id]);
+
+        $this->actingAs($user);
+        Filament::setCurrentPanel(Filament::getPanel('app'));
+        Filament::setTenant($teamA);
+
+        $ids = ConsolidationGroupResource::getEloquentQuery()->pluck('id')->all();
+
+        $this->assertContains($ownedByA->id, $ids);
+        $this->assertNotContains($ownedByB->id, $ids);
+    }
+
+    public function test_member_teams_persist_through_the_pivot(): void
+    {
+        $user = User::factory()->create();
+        $a = $this->team($user, 'A');
+        $b = $this->team($user, 'B');
+
+        $group = ConsolidationGroup::create(['name' => 'G', 'owner_team_id' => $a->id]);
+        $group->members()->sync([$a->id, $b->id]);
+
+        $this->assertSame(2, $group->members()->count());
+        $this->assertDatabaseHas('consolidation_group_team', [
+            'consolidation_group_id' => $group->id,
+            'team_id' => $b->id,
+        ]);
+    }
+
+    public function test_enforce_allowed_members_drops_teams_the_user_cannot_add(): void
+    {
+        $user = User::factory()->create();
+        $mine = $this->team($user, 'Mine');
+
+        $stranger = User::factory()->create();
+        $foreign = Team::forceCreate(['user_id' => $stranger->id, 'name' => 'Foreign', 'personal_team' => false]);
+
+        $group = ConsolidationGroup::create(['name' => 'G', 'owner_team_id' => $mine->id]);
+        // Simulate a crafted request attaching a team the user does not belong to.
+        $group->members()->sync([$mine->id, $foreign->id]);
+
+        $this->actingAs($user);
+        ConsolidationGroupResource::enforceAllowedMembers($group);
+
+        $ids = $group->members()->pluck('teams.id')->map(fn ($v): int => (int) $v)->all();
+        $this->assertContains($mine->id, $ids);
+        $this->assertNotContains($foreign->id, $ids);
+    }
+}

--- a/tests/Feature/Consolidation/ConsolidationServiceTest.php
+++ b/tests/Feature/Consolidation/ConsolidationServiceTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Consolidation;
+
+use App\Models\Account;
+use App\Models\ConsolidationGroup;
+use App\Models\JournalEntry;
+use App\Models\Team;
+use App\Models\User;
+use App\Services\ConsolidationService;
+use App\Services\FinancialStatementService;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ConsolidationServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    private Carbon $start;
+
+    private Carbon $end;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+        $this->start = Carbon::parse('2026-01-01');
+        $this->end = Carbon::parse('2026-12-31');
+    }
+
+    private function team(): Team
+    {
+        return Team::forceCreate(['user_id' => $this->user->id, 'name' => 'T', 'personal_team' => false]);
+    }
+
+    private function account(int $teamId, string $type): Account
+    {
+        return Account::factory()->create(['team_id' => $teamId, 'account_type' => $type]);
+    }
+
+    /**
+     * @param  array<int, array{0:int,1:float,2:float}>  $lines  [accountId, debit, credit]
+     */
+    private function postEntry(int $teamId, ?int $counterpartyId, array $lines): void
+    {
+        $entry = JournalEntry::create([
+            'team_id' => $teamId,
+            'user_id' => $this->user->id,
+            'entry_date' => '2026-06-15',
+            'counterparty_team_id' => $counterpartyId,
+            'is_posted' => true,
+        ]);
+
+        foreach ($lines as [$accountId, $debit, $credit]) {
+            $entry->lines()->create(['account_id' => $accountId, 'debit_amount' => $debit, 'credit_amount' => $credit]);
+        }
+    }
+
+    private function group(Team ...$members): ConsolidationGroup
+    {
+        $group = ConsolidationGroup::create(['name' => 'Group', 'owner_team_id' => $members[0]->id]);
+        $group->members()->syncWithoutDetaching(collect($members)->pluck('id')->all());
+
+        return $group;
+    }
+
+    public function test_profit_and_loss_aggregates_and_eliminates_intercompany(): void
+    {
+        $a = $this->team();
+        $b = $this->team();
+        $aRev = $this->account($a->id, 'revenue');
+        $aAr = $this->account($a->id, 'asset');
+        $bExp = $this->account($b->id, 'expense');
+        $bAp = $this->account($b->id, 'liability');
+
+        // External sale on A: revenue 200 (no counterparty).
+        $this->postEntry($a->id, null, [[$aAr->id, 200, 0], [$aRev->id, 0, 200]]);
+        // Intercompany sale A -> B: A revenue 100 (counterparty B) ...
+        $this->postEntry($a->id, $b->id, [[$aAr->id, 100, 0], [$aRev->id, 0, 100]]);
+        // ... and B expense 100 (counterparty A).
+        $this->postEntry($b->id, $a->id, [[$bExp->id, 100, 0], [$bAp->id, 0, 100]]);
+
+        $result = app(ConsolidationService::class)->consolidatedProfitAndLoss($this->group($a, $b), $this->start, $this->end);
+
+        // Combined double-counts the intercompany sale; consolidated nets it out.
+        $this->assertSame(300.0, $result['combined']['revenue']);
+        $this->assertSame(100.0, $result['eliminations']['revenue']);
+        $this->assertSame(100.0, $result['eliminations']['expenses']);
+        $this->assertSame(200.0, $result['consolidated']['revenue']);
+        $this->assertSame(0.0, $result['consolidated']['expenses']);
+        $this->assertSame(200.0, $result['consolidated']['net_income']);
+    }
+
+    public function test_balance_sheet_eliminates_intercompany_receivable_and_payable(): void
+    {
+        $a = $this->team();
+        $b = $this->team();
+        $aAr = $this->account($a->id, 'asset');
+        $aRev = $this->account($a->id, 'revenue');
+        $bExp = $this->account($b->id, 'expense');
+        $bAp = $this->account($b->id, 'liability');
+
+        $this->postEntry($a->id, null, [[$aAr->id, 200, 0], [$aRev->id, 0, 200]]);
+        $this->postEntry($a->id, $b->id, [[$aAr->id, 100, 0], [$aRev->id, 0, 100]]);
+        $this->postEntry($b->id, $a->id, [[$bExp->id, 100, 0], [$bAp->id, 0, 100]]);
+
+        $result = app(ConsolidationService::class)->consolidatedBalanceSheet($this->group($a, $b), $this->end);
+
+        $this->assertSame(300.0, $result['combined']['assets']);
+        $this->assertSame(100.0, $result['eliminations']['assets']);
+        $this->assertSame(100.0, $result['eliminations']['liabilities']);
+        $this->assertSame(200.0, $result['consolidated']['assets']);
+        $this->assertSame(0.0, $result['consolidated']['liabilities']);
+    }
+
+    public function test_cash_flow_consolidates_by_simple_sum_without_eliminations(): void
+    {
+        $a = $this->team();
+        $b = $this->team();
+
+        $result = app(ConsolidationService::class)->consolidatedCashFlow($this->group($a, $b), $this->start, $this->end);
+
+        $this->assertSame(0.0, $result['eliminations']['operating']);
+        $this->assertSame($result['combined'], $result['consolidated']);
+        $this->assertCount(2, $result['members']);
+    }
+
+    public function test_with_team_scopes_regardless_of_auth(): void
+    {
+        $x = $this->team();
+        $rev = $this->account($x->id, 'revenue');
+        $ar = $this->account($x->id, 'asset');
+        $this->postEntry($x->id, null, [[$ar->id, 150, 0], [$rev->id, 0, 150]]);
+
+        // No actingAs: withTeam() must still resolve team x's statement.
+        $pl = app(FinancialStatementService::class)->withTeam($x->id)->profitAndLoss($this->start, $this->end);
+        $this->assertSame(150.0, (float) $pl['revenue']['total']);
+
+        // Default (no override, no auth) → sentinel team -1 → empty.
+        $empty = app(FinancialStatementService::class)->profitAndLoss($this->start, $this->end);
+        $this->assertSame(0.0, (float) $empty['revenue']['total']);
+    }
+
+    public function test_empty_group_yields_zeros(): void
+    {
+        $owner = $this->team();
+        $group = ConsolidationGroup::create(['name' => 'Empty', 'owner_team_id' => $owner->id]);
+
+        $result = app(ConsolidationService::class)->consolidatedProfitAndLoss($group, $this->start, $this->end);
+
+        $this->assertSame(0.0, $result['consolidated']['net_income']);
+        $this->assertSame([], $result['members']);
+    }
+}


### PR DESCRIPTION
## What

Group-level financial statements aggregated across multiple **Team** tenants, with intercompany eliminations. Previously `FinancialStatementService` produced statements for one team only (scoped to `current_team_id`).

## How

- **`ConsolidationGroup`** + `consolidation_group_team` pivot (`members()` belongsToMany). A team can be in several groups.
- **`FinancialStatementService::withTeam(int)`** — an immutable override so consolidation computes any member team without an auth context. Every statement method already routes through `scopedTeamId()`, so this one change reparameterizes all of them; default (unscoped) behavior is unchanged.
- **`counterparty_team_id`** tag on `journal_entries` — marks an entry as intercompany with the other member team.
- **`ConsolidationService`** — aggregates each member's P&L / balance sheet / cash flow, then **nets out intercompany amounts**:
  - **P&L:** intercompany revenue nets against intercompany expense/COGS.
  - **Balance sheet:** intercompany receivables net against payables.
  - **Cash flow:** simple sum this increment (cash-flow-specific eliminations deferred).
- **Filament:** `ConsolidatedReports` page (pick group + period → combined / eliminations / consolidated) and a `ConsolidationGroup` resource to manage groups. View is gated to users who belong to a member team; a team only manages the groups it owns.

## Scope boundaries (approved)

Ships the elimination **engine + tag column + tests**; the intercompany-entry **authoring UI is deferred**. Single currency assumed. Cash-flow eliminations deferred.

## Tests / verification

- 11 tests (`tests/Feature/Consolidation/`): P&L + BS aggregation and elimination, cash-flow simple-sum, `withTeam` isolation, empty group, report generate + visibility gate, resource tenant scope + member-access enforcement.
- **Full suite green: SQLite (498) and MySQL** (new migrations + elimination joins verified on MySQL).
- **PHPStan (larastan, level max) clean.**
- Adversarial review pass — folded in both findings it raised:
  - **Cross-tenant leak (HIGH):** group members are now restricted to the acting user's own teams (option filter **and** server-side re-sync, since Filament doesn't re-validate submitted relationship IDs).
  - **Over-elimination (MED):** cash/bank excluded from intercompany asset elimination so a cash settlement can't inflate group cash; single-line-AR/AP constraint documented for the deferred authoring UI.

Design spec: `docs/superpowers/specs/2026-07-04-consolidated-reporting-design.md`.