### PR TITLE
feat: customer & vendor portals (P1-7)

### DIFF
--- a/app/Filament/Admin/Resources/Vendors/VendorResource.php
+++ b/app/Filament/Admin/Resources/Vendors/VendorResource.php
@@ -8,6 +8,8 @@ use App\Filament\Admin\Resources\Vendors\Pages\CreateVendor;
 use App\Filament\Admin\Resources\Vendors\Pages\EditVendor;
 use App\Filament\Admin\Resources\Vendors\Pages\ListVendors;
 use App\Models\Vendor;
+use App\Notifications\PortalAccessNotification;
+use Filament\Actions\Action;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\EditAction;
 use Filament\Forms\Components\Select;
@@ -86,6 +88,13 @@ class VendorResource extends Resource
             ])
             ->recordActions([
                 EditAction::make(),
+                Action::make('sendPortalInvite')
+                    ->label('Portal invite')
+                    ->icon('heroicon-o-envelope')
+                    ->requiresConfirmation()
+                    // Needs an email to send the signed link to.
+                    ->visible(fn (Vendor $record): bool => filled($record->email))
+                    ->action(fn (Vendor $record) => $record->notify(new PortalAccessNotification('vendor'))),
                 DeleteAction::make(),
             ]);
     }

--- a/app/Filament/App/Resources/Customers/CustomerResource.php
+++ b/app/Filament/App/Resources/Customers/CustomerResource.php
@@ -8,6 +8,8 @@ use App\Filament\App\Resources\Customers\Pages\CreateCustomer;
 use App\Filament\App\Resources\Customers\Pages\EditCustomer;
 use App\Filament\App\Resources\Customers\Pages\ListCustomers;
 use App\Models\Customer;
+use App\Notifications\PortalAccessNotification;
+use Filament\Actions\Action;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
@@ -102,6 +104,11 @@ class CustomerResource extends Resource
             ])
             ->recordActions([
                 EditAction::make(),
+                Action::make('sendPortalInvite')
+                    ->label('Portal invite')
+                    ->icon('heroicon-o-envelope')
+                    ->requiresConfirmation()
+                    ->action(fn (Customer $record) => $record->notify(new PortalAccessNotification('customer'))),
                 DeleteAction::make(),
             ])
             ->toolbarActions([

--- a/app/Filament/Customer/Pages/Auth/CustomerLogin.php
+++ b/app/Filament/Customer/Pages/Auth/CustomerLogin.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Customer\Pages\Auth;
+
+use Filament\Auth\Pages\Login;
+
+/**
+ * The customer's email lives in `customer_email`, not `email`, so map the
+ * login form's email field onto the real column before the guard looks it up.
+ */
+class CustomerLogin extends Login
+{
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    #[\Override]
+    protected function getCredentialsFromFormData(array $data): array
+    {
+        return [
+            'customer_email' => $data['email'],
+            'password' => $data['password'],
+        ];
+    }
+}

--- a/app/Filament/Customer/Resources/Invoices/Pages/ListPortalInvoices.php
+++ b/app/Filament/Customer/Resources/Invoices/Pages/ListPortalInvoices.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Customer\Resources\Invoices\Pages;
+
+use App\Filament\Customer\Resources\Invoices\PortalInvoiceResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListPortalInvoices extends ListRecords
+{
+    #[\Override]
+    protected static string $resource = PortalInvoiceResource::class;
+}

--- a/app/Filament/Customer/Resources/Invoices/PortalInvoiceResource.php
+++ b/app/Filament/Customer/Resources/Invoices/PortalInvoiceResource.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Customer\Resources\Invoices;
+
+use App\Filament\Customer\Resources\Invoices\Pages\ListPortalInvoices;
+use App\Models\Invoice;
+use Filament\Actions\Action;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Support\Enums\FontWeight;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Auth;
+
+/**
+ * The customer's own invoices — read-only. Every query is scoped to the logged-in
+ * customer; there is no create/edit/delete path.
+ */
+class PortalInvoiceResource extends Resource
+{
+    #[\Override]
+    protected static ?string $model = Invoice::class;
+
+    protected static bool $isScopedToTenant = false;
+
+    #[\Override]
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-document-text';
+
+    #[\Override]
+    protected static ?string $navigationLabel = 'My Invoices';
+
+    #[\Override]
+    protected static ?string $modelLabel = 'invoice';
+
+    #[\Override]
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()->where('customer_id', Auth::guard('customer')->id());
+    }
+
+    #[\Override]
+    public static function canCreate(): bool
+    {
+        return false;
+    }
+
+    #[\Override]
+    public static function canEdit(Model $record): bool
+    {
+        return false;
+    }
+
+    #[\Override]
+    public static function canDelete(Model $record): bool
+    {
+        return false;
+    }
+
+    #[\Override]
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('invoice_number')->searchable()->weight(FontWeight::Bold),
+                TextColumn::make('invoice_date')->date()->sortable(),
+                TextColumn::make('due_date')->date()->sortable(),
+                TextColumn::make('total_amount')->money()->sortable(),
+                TextColumn::make('payment_status')->badge(),
+            ])
+            ->defaultSort('invoice_date', 'desc')
+            ->recordActions([
+                Action::make('download')
+                    ->label('PDF')
+                    ->icon('heroicon-o-arrow-down-tray')
+                    ->action(function (Invoice $record) {
+                        // Defence in depth: the record already comes from the
+                        // customer-scoped query, but generatePDF() is shared with
+                        // staff resources, so re-verify ownership here too.
+                        abort_unless($record->customer_id === Auth::guard('customer')->id(), 403);
+
+                        return $record->generatePDF();
+                    }),
+            ])
+            ->toolbarActions([]);
+    }
+
+    #[\Override]
+    public static function infolist(Schema $schema): Schema
+    {
+        return $schema->components([]);
+    }
+
+    #[\Override]
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListPortalInvoices::route('/'),
+        ];
+    }
+}

--- a/app/Filament/Customer/Widgets/PortalBalanceWidget.php
+++ b/app/Filament/Customer/Widgets/PortalBalanceWidget.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Customer\Widgets;
+
+use App\Models\Invoice;
+use Filament\Widgets\StatsOverviewWidget as BaseWidget;
+use Filament\Widgets\StatsOverviewWidget\Stat;
+use Illuminate\Support\Facades\Auth;
+
+class PortalBalanceWidget extends BaseWidget
+{
+    /**
+     * @return array<int, Stat>
+     */
+    #[\Override]
+    protected function getStats(): array
+    {
+        $customerId = Auth::guard('customer')->id();
+
+        $outstanding = (float) Invoice::query()
+            ->where('customer_id', $customerId)
+            ->where('payment_status', '!=', 'paid')
+            ->sum('total_amount');
+
+        $count = Invoice::query()->where('customer_id', $customerId)->count();
+
+        return [
+            Stat::make('Outstanding balance', number_format($outstanding, 2)),
+            Stat::make('Invoices', (string) $count),
+        ];
+    }
+}

--- a/app/Filament/Vendor/Resources/Bills/Pages/ListPortalBills.php
+++ b/app/Filament/Vendor/Resources/Bills/Pages/ListPortalBills.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Vendor\Resources\Bills\Pages;
+
+use App\Filament\Vendor\Resources\Bills\PortalBillResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListPortalBills extends ListRecords
+{
+    #[\Override]
+    protected static string $resource = PortalBillResource::class;
+}

--- a/app/Filament/Vendor/Resources/Bills/PortalBillResource.php
+++ b/app/Filament/Vendor/Resources/Bills/PortalBillResource.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Vendor\Resources\Bills;
+
+use App\Filament\Vendor\Resources\Bills\Pages\ListPortalBills;
+use App\Models\Bill;
+use Filament\Resources\Resource;
+use Filament\Support\Enums\FontWeight;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Auth;
+
+/**
+ * The vendor's own bills — read-only, scoped to the logged-in vendor.
+ */
+class PortalBillResource extends Resource
+{
+    #[\Override]
+    protected static ?string $model = Bill::class;
+
+    protected static bool $isScopedToTenant = false;
+
+    #[\Override]
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-document-text';
+
+    #[\Override]
+    protected static ?string $navigationLabel = 'My Bills';
+
+    #[\Override]
+    protected static ?string $modelLabel = 'bill';
+
+    #[\Override]
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()->where('vendor_id', Auth::guard('vendor')->id());
+    }
+
+    #[\Override]
+    public static function canCreate(): bool
+    {
+        return false;
+    }
+
+    #[\Override]
+    public static function canEdit(Model $record): bool
+    {
+        return false;
+    }
+
+    #[\Override]
+    public static function canDelete(Model $record): bool
+    {
+        return false;
+    }
+
+    #[\Override]
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('bill_number')->searchable()->weight(FontWeight::Bold),
+                TextColumn::make('bill_date')->date()->sortable(),
+                TextColumn::make('due_date')->date()->sortable(),
+                TextColumn::make('total_amount')->money()->sortable(),
+                TextColumn::make('amount_paid')->money()->sortable(),
+                TextColumn::make('payment_status')->badge(),
+            ])
+            ->defaultSort('bill_date', 'desc')
+            ->toolbarActions([]);
+    }
+
+    #[\Override]
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListPortalBills::route('/'),
+        ];
+    }
+}

--- a/app/Filament/Vendor/Resources/VendorCredits/Pages/ListPortalVendorCredits.php
+++ b/app/Filament/Vendor/Resources/VendorCredits/Pages/ListPortalVendorCredits.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Vendor\Resources\VendorCredits\Pages;
+
+use App\Filament\Vendor\Resources\VendorCredits\PortalVendorCreditResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListPortalVendorCredits extends ListRecords
+{
+    #[\Override]
+    protected static string $resource = PortalVendorCreditResource::class;
+}

--- a/app/Filament/Vendor/Resources/VendorCredits/PortalVendorCreditResource.php
+++ b/app/Filament/Vendor/Resources/VendorCredits/PortalVendorCreditResource.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Vendor\Resources\VendorCredits;
+
+use App\Filament\Vendor\Resources\VendorCredits\Pages\ListPortalVendorCredits;
+use App\Models\VendorCredit;
+use Filament\Resources\Resource;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Auth;
+
+/**
+ * The vendor's own credit notes — read-only, scoped to the logged-in vendor.
+ */
+class PortalVendorCreditResource extends Resource
+{
+    #[\Override]
+    protected static ?string $model = VendorCredit::class;
+
+    protected static bool $isScopedToTenant = false;
+
+    #[\Override]
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-receipt-refund';
+
+    #[\Override]
+    protected static ?string $navigationLabel = 'My Credits';
+
+    #[\Override]
+    protected static ?string $modelLabel = 'credit';
+
+    #[\Override]
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()->where('vendor_id', Auth::guard('vendor')->id());
+    }
+
+    #[\Override]
+    public static function canCreate(): bool
+    {
+        return false;
+    }
+
+    #[\Override]
+    public static function canEdit(Model $record): bool
+    {
+        return false;
+    }
+
+    #[\Override]
+    public static function canDelete(Model $record): bool
+    {
+        return false;
+    }
+
+    #[\Override]
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('credit_date')->date()->sortable(),
+                TextColumn::make('total_amount')->money()->sortable(),
+                TextColumn::make('amount_remaining')->money()->sortable(),
+                TextColumn::make('status')->badge(),
+            ])
+            ->defaultSort('credit_date', 'desc')
+            ->toolbarActions([]);
+    }
+
+    #[\Override]
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListPortalVendorCredits::route('/'),
+        ];
+    }
+}

--- a/app/Filament/Vendor/Widgets/PortalBalanceWidget.php
+++ b/app/Filament/Vendor/Widgets/PortalBalanceWidget.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Vendor\Widgets;
+
+use App\Models\Bill;
+use Filament\Widgets\StatsOverviewWidget as BaseWidget;
+use Filament\Widgets\StatsOverviewWidget\Stat;
+use Illuminate\Support\Facades\Auth;
+
+class PortalBalanceWidget extends BaseWidget
+{
+    /**
+     * @return array<int, Stat>
+     */
+    #[\Override]
+    protected function getStats(): array
+    {
+        $vendorId = Auth::guard('vendor')->id();
+
+        $outstanding = (float) Bill::query()
+            ->where('vendor_id', $vendorId)
+            ->where('payment_status', '!=', 'paid')
+            ->sum('total_amount');
+
+        $count = Bill::query()->where('vendor_id', $vendorId)->count();
+
+        return [
+            Stat::make('Outstanding balance', number_format($outstanding, 2)),
+            Stat::make('Bills', (string) $count),
+        ];
+    }
+}

--- a/app/Http/Controllers/PortalAccessController.php
+++ b/app/Http/Controllers/PortalAccessController.php
@@ -9,6 +9,7 @@ use App\Models\Vendor;
 use App\Notifications\PortalAccessNotification;
 use Filament\Facades\Filament;
 use Illuminate\Contracts\View\View;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Validation\Rules\Password;
@@ -19,7 +20,7 @@ use Illuminate\Validation\Rules\Password;
  */
 class PortalAccessController extends Controller
 {
-    /** @var array<string, class-string<\Illuminate\Database\Eloquent\Model>> */
+    /** @var array<string, class-string<Model>> */
     private const MODELS = ['customer' => Customer::class, 'vendor' => Vendor::class];
 
     /** Email column per guard (Customer's is non-standard). */
@@ -28,7 +29,8 @@ class PortalAccessController extends Controller
     public function showSetPassword(Request $request, int $id): View
     {
         $guard = $this->guard($request);
-        $this->modelClass($guard)::findOrFail($id);
+        $model = $this->modelClass($guard)::findOrFail($id);
+        $this->assertLinkFresh($request, $model);
 
         return view('portal.set-password', ['action' => $request->fullUrl()]);
     }
@@ -36,9 +38,11 @@ class PortalAccessController extends Controller
     public function setPassword(Request $request, int $id): RedirectResponse
     {
         $guard = $this->guard($request);
+        $model = $this->modelClass($guard)::findOrFail($id);
+        $this->assertLinkFresh($request, $model);
+
         $request->validate(['password' => ['required', 'confirmed', Password::defaults()]]);
 
-        $model = $this->modelClass($guard)::findOrFail($id);
         $model->password = $request->string('password')->value();
         $model->save();
 
@@ -69,6 +73,19 @@ class PortalAccessController extends Controller
         return back()->with('status', 'If that email is on file, a set-password link has been sent.');
     }
 
+    /**
+     * The link carries sha1 of the password as it was when minted. Once a
+     * password is set that hash changes, so a reused or leaked link 403s —
+     * effectively single-use (mirrors Laravel's signed email-verification).
+     */
+    private function assertLinkFresh(Request $request, Model $model): void
+    {
+        abort_unless(
+            hash_equals((string) $request->query('hash'), sha1((string) $model->getAttribute('password'))),
+            403,
+        );
+    }
+
     private function guard(Request $request): string
     {
         $guard = (string) $request->route('guard');
@@ -78,7 +95,7 @@ class PortalAccessController extends Controller
     }
 
     /**
-     * @return class-string<\Illuminate\Database\Eloquent\Model>
+     * @return class-string<Model>
      */
     private function modelClass(string $guard): string
     {

--- a/app/Http/Controllers/PortalAccessController.php
+++ b/app/Http/Controllers/PortalAccessController.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Models\Customer;
+use App\Models\Vendor;
+use App\Notifications\PortalAccessNotification;
+use Filament\Facades\Filament;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rules\Password;
+
+/**
+ * Signed-link set-password + forgot-password flow shared by both portals. The
+ * guard ('customer' | 'vendor') comes from the route default, never user input.
+ */
+class PortalAccessController extends Controller
+{
+    /** @var array<string, class-string<\Illuminate\Database\Eloquent\Model>> */
+    private const MODELS = ['customer' => Customer::class, 'vendor' => Vendor::class];
+
+    /** Email column per guard (Customer's is non-standard). */
+    private const EMAIL_COLUMN = ['customer' => 'customer_email', 'vendor' => 'email'];
+
+    public function showSetPassword(Request $request, int $id): View
+    {
+        $guard = $this->guard($request);
+        $this->modelClass($guard)::findOrFail($id);
+
+        return view('portal.set-password', ['action' => $request->fullUrl()]);
+    }
+
+    public function setPassword(Request $request, int $id): RedirectResponse
+    {
+        $guard = $this->guard($request);
+        $request->validate(['password' => ['required', 'confirmed', Password::defaults()]]);
+
+        $model = $this->modelClass($guard)::findOrFail($id);
+        $model->password = $request->string('password')->value();
+        $model->save();
+
+        return redirect(Filament::getPanel($guard)->getLoginUrl())
+            ->with('status', 'Password set — please log in.');
+    }
+
+    public function showForgot(Request $request): View
+    {
+        $guard = $this->guard($request);
+
+        return view('portal.forgot', ['action' => route("portal.{$guard}.forgot.send")]);
+    }
+
+    public function sendForgot(Request $request): RedirectResponse
+    {
+        $guard = $this->guard($request);
+        $request->validate(['email' => ['required', 'email']]);
+
+        $model = $this->modelClass($guard)::query()
+            ->where(self::EMAIL_COLUMN[$guard], $request->string('email')->value())
+            ->first();
+
+        // Send only for a real record, but always return the same message so a
+        // caller can't probe which emails exist (no account enumeration).
+        $model?->notify(new PortalAccessNotification($guard));
+
+        return back()->with('status', 'If that email is on file, a set-password link has been sent.');
+    }
+
+    private function guard(Request $request): string
+    {
+        $guard = (string) $request->route('guard');
+        abort_unless(array_key_exists($guard, self::MODELS), 404);
+
+        return $guard;
+    }
+
+    /**
+     * @return class-string<\Illuminate\Database\Eloquent\Model>
+     */
+    private function modelClass(string $guard): string
+    {
+        return self::MODELS[$guard];
+    }
+}

--- a/app/Models/Customer.php
+++ b/app/Models/Customer.php
@@ -5,17 +5,32 @@ declare(strict_types=1);
 namespace App\Models;
 
 use App\Traits\IsTenantModel;
+use Filament\Models\Contracts\FilamentUser;
+use Filament\Panel;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
-class Customer extends Authenticatable
+class Customer extends Authenticatable implements FilamentUser
 {
     use HasFactory, Notifiable;
     use IsTenantModel;
 
     // protected $primaryKey = 'customer_id';
     protected $guard = 'customer';
+
+    #[\Override]
+    protected $casts = [
+        'password' => 'hashed',
+    ];
+
+    /**
+     * Customers may reach only their own portal — never the staff panels.
+     */
+    public function canAccessPanel(Panel $panel): bool
+    {
+        return $panel->getId() === 'customer';
+    }
 
     #[\Override]
     protected $fillable = [

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -109,7 +109,8 @@ class User extends Authenticatable implements FilamentUser, HasDefaultTenant, Ha
 
     public function canAccessPanel(Panel $panel): bool
     {
-        return $this->hasVerifiedEmail();
+        // Staff reach only the staff panels — never the customer/vendor portals.
+        return in_array($panel->getId(), ['admin', 'app'], true) && $this->hasVerifiedEmail();
     }
 
     public function canAccessFilament(): bool

--- a/app/Models/Vendor.php
+++ b/app/Models/Vendor.php
@@ -5,16 +5,23 @@ declare(strict_types=1);
 namespace App\Models;
 
 use App\Traits\IsTenantModel;
+use Filament\Models\Contracts\FilamentUser;
+use Filament\Panel;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Notifications\Notifiable;
 
-class Vendor extends Model
+class Vendor extends Authenticatable implements FilamentUser
 {
     use HasFactory;
     use IsTenantModel;
+    use Notifiable;
 
     #[\Override]
     protected $primaryKey = 'vendor_id';
+
+    /** Auth guard for the vendor portal. */
+    protected string $guard = 'vendor';
 
     #[\Override]
     protected $fillable = [
@@ -26,6 +33,25 @@ class Vendor extends Model
         'payment_terms',
         'status',
     ];
+
+    #[\Override]
+    protected $hidden = [
+        'password',
+        'remember_token',
+    ];
+
+    #[\Override]
+    protected $casts = [
+        'password' => 'hashed',
+    ];
+
+    /**
+     * Vendors may reach only their own portal — never the staff panels.
+     */
+    public function canAccessPanel(Panel $panel): bool
+    {
+        return $panel->getId() === 'vendor';
+    }
 
     public function invoices()
     {

--- a/app/Notifications/PortalAccessNotification.php
+++ b/app/Notifications/PortalAccessNotification.php
@@ -34,7 +34,9 @@ class PortalAccessNotification extends Notification implements ShouldQueue
         $url = URL::temporarySignedRoute(
             "portal.{$this->guard}.set-password",
             now()->addHours(24),
-            ['id' => $notifiable->getKey()],
+            // hash of the current password → the link stops working the moment a
+            // password is set (single-use), so a leaked link can't take over later.
+            ['id' => $notifiable->getKey(), 'hash' => sha1((string) $notifiable->password)],
         );
 
         return (new MailMessage)

--- a/app/Notifications/PortalAccessNotification.php
+++ b/app/Notifications/PortalAccessNotification.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+use Illuminate\Support\Facades\URL;
+
+/**
+ * Emails a signed, expiring set-password link to a customer or vendor. Used for
+ * both the initial invite and "forgot password" — the link is the only way in,
+ * so it is time-limited and tamper-proof (Laravel signed URL).
+ */
+class PortalAccessNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(private readonly string $guard) {}
+
+    /**
+     * @return array<int, string>
+     */
+    public function via(mixed $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(mixed $notifiable): MailMessage
+    {
+        $url = URL::temporarySignedRoute(
+            "portal.{$this->guard}.set-password",
+            now()->addHours(24),
+            ['id' => $notifiable->getKey()],
+        );
+
+        return (new MailMessage)
+            ->subject('Set up your portal access')
+            ->line('Set a password to access your portal.')
+            ->action('Set password', $url)
+            ->line('This link expires in 24 hours. If you did not expect this, ignore it.');
+    }
+}

--- a/app/Providers/Filament/CustomerPanelProvider.php
+++ b/app/Providers/Filament/CustomerPanelProvider.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Providers\Filament;
+
+use App\Filament\Customer\Pages\Auth\CustomerLogin;
+use Filament\Http\Middleware\Authenticate;
+use Filament\Http\Middleware\DisableBladeIconComponents;
+use Filament\Http\Middleware\DispatchServingFilamentEvent;
+use Filament\Pages\Dashboard;
+use Filament\Panel;
+use Filament\PanelProvider;
+use Filament\Support\Colors\Color;
+use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
+use Illuminate\Cookie\Middleware\EncryptCookies;
+use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
+use Illuminate\Routing\Middleware\SubstituteBindings;
+use Illuminate\Session\Middleware\AuthenticateSession;
+use Illuminate\Session\Middleware\StartSession;
+use Illuminate\View\Middleware\ShareErrorsFromSession;
+
+/**
+ * Customer self-service portal. Guard `customer`; no tenancy — a customer's
+ * own identity is the scope. Read-only resources are discovered from
+ * app/Filament/Customer/Resources.
+ */
+class CustomerPanelProvider extends PanelProvider
+{
+    public function panel(Panel $panel): Panel
+    {
+        return $panel
+            ->id('customer')
+            ->path('portal')
+            ->authGuard('customer')
+            ->login(CustomerLogin::class)
+            ->brandName('Customer Portal')
+            ->colors([
+                'primary' => Color::Emerald,
+            ])
+            ->discoverResources(in: app_path('Filament/Customer/Resources'), for: 'App\\Filament\\Customer\\Resources')
+            ->discoverPages(in: app_path('Filament/Customer/Pages'), for: 'App\\Filament\\Customer\\Pages')
+            ->discoverWidgets(in: app_path('Filament/Customer/Widgets'), for: 'App\\Filament\\Customer\\Widgets')
+            ->pages([
+                Dashboard::class,
+            ])
+            ->middleware([
+                EncryptCookies::class,
+                AddQueuedCookiesToResponse::class,
+                StartSession::class,
+                AuthenticateSession::class,
+                ShareErrorsFromSession::class,
+                VerifyCsrfToken::class,
+                SubstituteBindings::class,
+                DisableBladeIconComponents::class,
+                DispatchServingFilamentEvent::class,
+            ])
+            ->authMiddleware([
+                Authenticate::class,
+            ]);
+    }
+}

--- a/app/Providers/Filament/VendorPanelProvider.php
+++ b/app/Providers/Filament/VendorPanelProvider.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Providers\Filament;
+
+use Filament\Http\Middleware\Authenticate;
+use Filament\Http\Middleware\DisableBladeIconComponents;
+use Filament\Http\Middleware\DispatchServingFilamentEvent;
+use Filament\Pages\Dashboard;
+use Filament\Panel;
+use Filament\PanelProvider;
+use Filament\Support\Colors\Color;
+use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
+use Illuminate\Cookie\Middleware\EncryptCookies;
+use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
+use Illuminate\Routing\Middleware\SubstituteBindings;
+use Illuminate\Session\Middleware\AuthenticateSession;
+use Illuminate\Session\Middleware\StartSession;
+use Illuminate\View\Middleware\ShareErrorsFromSession;
+
+/**
+ * Vendor self-service portal. Guard `vendor`; no tenancy. Read-only resources
+ * are discovered from app/Filament/Vendor/Resources. Vendor's auth username is
+ * the standard `email` column, so the default Filament login page works.
+ */
+class VendorPanelProvider extends PanelProvider
+{
+    public function panel(Panel $panel): Panel
+    {
+        return $panel
+            ->id('vendor')
+            ->path('vendor-portal')
+            ->authGuard('vendor')
+            ->login()
+            ->brandName('Vendor Portal')
+            ->colors([
+                'primary' => Color::Amber,
+            ])
+            ->discoverResources(in: app_path('Filament/Vendor/Resources'), for: 'App\\Filament\\Vendor\\Resources')
+            ->discoverPages(in: app_path('Filament/Vendor/Pages'), for: 'App\\Filament\\Vendor\\Pages')
+            ->discoverWidgets(in: app_path('Filament/Vendor/Widgets'), for: 'App\\Filament\\Vendor\\Widgets')
+            ->pages([
+                Dashboard::class,
+            ])
+            ->middleware([
+                EncryptCookies::class,
+                AddQueuedCookiesToResponse::class,
+                StartSession::class,
+                AuthenticateSession::class,
+                ShareErrorsFromSession::class,
+                VerifyCsrfToken::class,
+                SubstituteBindings::class,
+                DisableBladeIconComponents::class,
+                DispatchServingFilamentEvent::class,
+            ])
+            ->authMiddleware([
+                Authenticate::class,
+            ]);
+    }
+}

--- a/bootstrap/cache/services.php
+++ b/bootstrap/cache/services.php
@@ -69,10 +69,12 @@
     65 => 'App\\Providers\\EventServiceProvider',
     66 => 'App\\Providers\\Filament\\AdminPanelProvider',
     67 => 'App\\Providers\\Filament\\AppPanelProvider',
-    68 => 'App\\Providers\\RouteServiceProvider',
-    69 => 'App\\Providers\\TeamServiceProvider',
-    70 => 'App\\Providers\\JetstreamServiceProvider',
-    71 => 'App\\Providers\\FortifyServiceProvider',
+    68 => 'App\\Providers\\Filament\\CustomerPanelProvider',
+    69 => 'App\\Providers\\Filament\\VendorPanelProvider',
+    70 => 'App\\Providers\\RouteServiceProvider',
+    71 => 'App\\Providers\\TeamServiceProvider',
+    72 => 'App\\Providers\\JetstreamServiceProvider',
+    73 => 'App\\Providers\\FortifyServiceProvider',
   ),
   'eager' => 
   array (
@@ -127,10 +129,12 @@
     48 => 'App\\Providers\\EventServiceProvider',
     49 => 'App\\Providers\\Filament\\AdminPanelProvider',
     50 => 'App\\Providers\\Filament\\AppPanelProvider',
-    51 => 'App\\Providers\\RouteServiceProvider',
-    52 => 'App\\Providers\\TeamServiceProvider',
-    53 => 'App\\Providers\\JetstreamServiceProvider',
-    54 => 'App\\Providers\\FortifyServiceProvider',
+    51 => 'App\\Providers\\Filament\\CustomerPanelProvider',
+    52 => 'App\\Providers\\Filament\\VendorPanelProvider',
+    53 => 'App\\Providers\\RouteServiceProvider',
+    54 => 'App\\Providers\\TeamServiceProvider',
+    55 => 'App\\Providers\\JetstreamServiceProvider',
+    56 => 'App\\Providers\\FortifyServiceProvider',
   ),
   'deferred' => 
   array (

--- a/config/app.php
+++ b/config/app.php
@@ -180,6 +180,8 @@ return [
         EventServiceProvider::class,
         AdminPanelProvider::class,
         AppPanelProvider::class,
+        App\Providers\Filament\CustomerPanelProvider::class,
+        App\Providers\Filament\VendorPanelProvider::class,
         RouteServiceProvider::class,
 
         TeamServiceProvider::class,

--- a/config/auth.php
+++ b/config/auth.php
@@ -43,6 +43,16 @@ return [
             'driver' => 'session',
             'provider' => 'users',
         ],
+
+        'customer' => [
+            'driver' => 'session',
+            'provider' => 'customers',
+        ],
+
+        'vendor' => [
+            'driver' => 'session',
+            'provider' => 'vendors',
+        ],
     ],
 
     /*
@@ -68,10 +78,15 @@ return [
             'model' => User::class,
         ],
 
-        // 'users' => [
-        //     'driver' => 'database',
-        //     'table' => 'users',
-        // ],
+        'customers' => [
+            'driver' => 'eloquent',
+            'model' => App\Models\Customer::class,
+        ],
+
+        'vendors' => [
+            'driver' => 'eloquent',
+            'model' => App\Models\Vendor::class,
+        ],
     ],
 
     /*

--- a/database/migrations/2026_07_04_120001_add_portal_auth_to_customers_table.php
+++ b/database/migrations/2026_07_04_120001_add_portal_auth_to_customers_table.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+// Customer extends Authenticatable (guard 'customer') but the table never had a
+// password — customers could not actually log in. Portal access needs these.
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('customers', function (Blueprint $table): void {
+            $table->string('password')->nullable()->after('customer_city');
+            $table->rememberToken();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('customers', function (Blueprint $table): void {
+            $table->dropColumn(['password', 'remember_token']);
+        });
+    }
+};

--- a/database/migrations/2026_07_04_120002_add_portal_auth_to_vendors_table.php
+++ b/database/migrations/2026_07_04_120002_add_portal_auth_to_vendors_table.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+// Make Vendor authenticatable for the vendor portal. email is the auth username,
+// so it gets a (nullable) unique index — duplicates would make login ambiguous.
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('vendors', function (Blueprint $table): void {
+            $table->string('password')->nullable()->after('email');
+            $table->rememberToken();
+            $table->unique('email');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('vendors', function (Blueprint $table): void {
+            $table->dropUnique(['email']);
+            $table->dropColumn(['password', 'remember_token']);
+        });
+    }
+};

--- a/docs/superpowers/specs/2026-07-04-customer-vendor-portals-design.md
+++ b/docs/superpowers/specs/2026-07-04-customer-vendor-portals-design.md
@@ -1,0 +1,85 @@
+# Customer & Vendor Portals — Design
+
+**Status:** approved (design) · **Date:** 2026-07-04 · **Backlog:** P1-7
+
+## Problem
+
+There is no external self-service. `Customer` extends `Authenticatable` with `protected $guard = 'customer'`, but **the guard is not configured**, the `customers` table has **no `password`/`remember_token` column**, and there are no portal routes/panels. `Vendor` is a plain `Model` — not authenticatable at all. Customers and vendors cannot log in to see their own invoices/bills.
+
+## Decisions (locked)
+
+- **Both portals** — customer and vendor — as **Filament panels**, one per auth guard.
+- **Read-only, own records only:** invoices (customer) / bills + vendor-credits (vendor), an outstanding-balance dashboard, and document PDF download. No pay-online, profile edit, or statements this increment.
+- **Access:** invite + set-password. Staff send a portal invite; the external user sets a password and logs in.
+
+## Scope boundaries / YAGNI
+
+- No online payment (no gateway exists — separate epic). No profile editing, account statements, messaging, or document upload.
+- **Password reset uses the same signed-link mechanism as invite** (email a signed set-password link on demand) rather than Laravel's password-broker. Rationale: `Customer`'s email column is `customer_email` (non-standard), which fights the broker's `email`-keyed provider/token flow; a signed link is leaner, needs no reset-token tables, and avoids account-enumeration collisions with the staff `users` table. (Broker-based reset can be added later if needed.)
+
+## Architecture
+
+### 1. Auth foundation
+
+**Migrations**
+- `customers`: add `password` (string, nullable), `remember_token`.
+- `vendors`: add `password` (string, nullable), `remember_token`, and a **nullable-unique index on `email`** — email is the vendor's auth username, so duplicates would make `retrieveByCredentials` ambiguous (it returns the first match). A vendor needs an email before it can be invited (validated at invite time).
+
+**`config/auth.php`**
+- Guards: `customer` `{driver: session, provider: customers}`, `vendor` `{driver: session, provider: vendors}`.
+- Providers: `customers` `{eloquent, Customer}`, `vendors` `{eloquent, Vendor}`.
+- No new `passwords` brokers (reset is signed-link based).
+
+**Models**
+- `Vendor` → extend `Illuminate\Foundation\Auth\User as Authenticatable`, `use Notifiable`, `protected $guard = 'vendor'`, hide `password`/`remember_token`, keep `vendor_id` PK. Auth username = `email`.
+- `Customer` — already `Authenticatable`; add `password`/`remember_token` to `$hidden` (present) and implement `FilamentUser`. Auth username = `customer_email`.
+- Both implement `Filament\Models\Contracts\FilamentUser::canAccessPanel(Panel $panel): bool` → true **only** for their own portal panel id (`customer` / `vendor`), false otherwise. Staff `User::canAccessPanel` already gates admin/app; ensure it returns false for portal panels.
+
+### 2. Invite / set-password / forgot (shared flow — the security-critical core)
+
+- **`PortalAccessNotification`** (mail) — a signed, expiring URL to the set-password page. One notification, parameterized by guard + route.
+- **Staff invite:** a "Send portal invite" Filament action on the existing staff Customer and Vendor resources (`app/Filament/App/Resources/...` / admin) → sends the notification. (Vendor action disabled/validated when the vendor has no email.)
+- **Set-password page:** signed routes
+  - `GET /portal/set-password/{customer}` (name `portal.customer.set-password`) + vendor equivalent, protected by the `signed` middleware (tamper/expiry enforced by Laravel signed URLs; `URL::temporarySignedRoute(..., now()->addHours(24), [...])`).
+  - `POST` sets a hashed password on that record (min-length validated), then redirects to the panel login.
+- **Forgot password:** `GET /portal/forgot` (+ vendor) — enter email → if a matching record exists, email the signed set-password link; **always** show the same success message (no account enumeration). Rate-limited (`throttle`).
+- A single small `PortalAccessController` handles set-password + forgot for both guards (guard resolved from the route), keeping the flow in one auditable place.
+
+### 3. Filament portal panels (2)
+
+- **`CustomerPanelProvider`** — id `customer`, path `portal`, `authGuard('customer')`, **no tenancy**, `->login(CustomerPortalLogin::class)`, brand. Register in `bootstrap/providers.php`.
+- **`VendorPanelProvider`** — id `vendor`, path `vendor-portal`, `authGuard('vendor')`, `->login(VendorPortalLogin::class)`.
+- **Custom login pages:** extend Filament's `Login`; override `getCredentialsFromFormData()` to map the form `email` field to the model's column — `['customer_email' => $data['email'], 'password' => ...]` for customer, `['email' => ...]` for vendor. (Needed because the customer's column is `customer_email`.) The login form still shows an "Email" field.
+
+### 4. Read-only, self-scoped resources
+
+- **Customer panel — `PortalInvoiceResource`** (model `Invoice`): `getEloquentQuery()` → `where('customer_id', Auth::guard('customer')->id())`. **Read-only:** `canCreate/canEdit/canDelete = false`; table + a `ViewAction` (infolist) showing number, date, due date, amount, payment status. A **PDF download** action → the existing `Invoice::generatePDF()`, itself re-checking `customer_id === auth id`.
+- **Vendor panel — `PortalBillResource`** (model `Bill`, PK `bill_id`): scoped `where('vendor_id', Auth::guard('vendor')->id())`, read-only, view + PDF. Plus a read-only `PortalVendorCreditResource` (or a simple list) scoped to the vendor.
+- **Balance dashboard widget** per panel: sum of the auth user's unpaid invoices/bills (a stat card). Scoped to the auth id.
+
+## Security (emphasis — external auth)
+
+- Every portal query is scoped to `Auth::guard(...)->id()`; no unscoped list is ever exposed. Resources are read-only.
+- `canAccessPanel` strictly isolates: a customer can reach only `/portal`, a vendor only `/vendor-portal`, staff neither; customers/vendors cannot reach admin/app.
+- Invite/reset links are **signed + expiring**; forgot-password does not reveal whether an email exists; login + forgot are throttled.
+- PDF/view actions re-verify ownership server-side (defence in depth beyond the scoped query).
+- Portal panels set no tenant (the auth identity *is* the scope) — no team leakage.
+
+## Testing (PHPUnit; heavy on isolation)
+
+1. **Cross-record isolation:** customer A logging in sees only A's invoices, never B's (query scope); same for vendor bills.
+2. **Panel isolation:** `Customer::canAccessPanel` true for `customer`, false for `vendor`/`admin`/`app`; `Vendor` symmetric; staff `User` false for both portals.
+3. **Read-only:** `PortalInvoiceResource::canCreate()/canEdit()/canDelete()` are false.
+4. **Invite set-password:** a valid signed URL sets a working password (login succeeds after); a tampered/expired URL is rejected (403).
+5. **Forgot enumeration:** unknown email and known email both return the same response; a link is sent only for a real record.
+6. **Balance widget:** equals the sum of the auth user's unpaid documents, excludes other users'.
+7. **PDF authz:** a customer cannot download another customer's invoice PDF.
+
+## Files
+
+- **New:** `CustomerPanelProvider`, `VendorPanelProvider`, `CustomerPortalLogin`, `VendorPortalLogin`, `PortalAccessController`, `PortalAccessNotification`, `PortalInvoiceResource` (+Pages), `PortalBillResource` (+Pages), `PortalVendorCreditResource` (or list), balance widgets, portal routes, migrations (customers/vendors auth cols), `tests/Feature/Portal/*`.
+- **Changed:** `config/auth.php`, `bootstrap/providers.php`, `app/Models/{Customer,Vendor}.php`, the staff Customer/Vendor resources (invite action), `routes/web.php` (portal routes).
+
+## Build order
+
+Auth foundation (migrations, auth.php, Vendor authenticatable, canAccessPanel, invite/set-password/forgot flow, custom login pages) lands first. Then the **customer panel** and **vendor panel** (providers + read-only scoped resources + balance widgets + PDF) parallelize on disjoint files.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -373,6 +373,12 @@ parameters:
 			path: app/Filament/App/Pages/ConsolidatedReports.php
 
 		-
+			message: '#^Call to an undefined method App\\Models\\Customer\|App\\Models\\User\|App\\Models\\Vendor\:\:allTeams\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: app/Filament/App/Pages/ConsolidatedReports.php
+
+		-
 			message: '#^Cannot call method fill\(\) on mixed\.$#'
 			identifier: method.nonObject
 			count: 1
@@ -403,7 +409,7 @@ parameters:
 			path: app/Filament/App/Pages/CreateTeam.php
 
 		-
-			message: '#^Parameter \#1 \$user of method App\\Actions\\Jetstream\\CreateTeam\:\:create\(\) expects App\\Models\\User, App\\Models\\User\|null given\.$#'
+			message: '#^Parameter \#1 \$user of method App\\Actions\\Jetstream\\CreateTeam\:\:create\(\) expects App\\Models\\User, App\\Models\\Customer\|App\\Models\\User\|App\\Models\\Vendor\|null given\.$#'
 			identifier: argument.type
 			count: 1
 			path: app/Filament/App/Pages/CreateTeam.php
@@ -445,7 +451,7 @@ parameters:
 			path: app/Filament/App/Pages/EditProfile.php
 
 		-
-			message: '#^Property App\\Filament\\App\\Pages\\EditProfile\:\:\$user \(App\\Models\\User\) does not accept App\\Models\\User\|null\.$#'
+			message: '#^Property App\\Filament\\App\\Pages\\EditProfile\:\:\$user \(App\\Models\\User\) does not accept App\\Models\\Customer\|App\\Models\\User\|App\\Models\\Vendor\|null\.$#'
 			identifier: assign.propertyType
 			count: 1
 			path: app/Filament/App/Pages/EditProfile.php
@@ -457,7 +463,7 @@ parameters:
 			path: app/Filament/App/Pages/EditTeam.php
 
 		-
-			message: '#^Method App\\Filament\\App\\Pages\\EditTeam\:\:user\(\) should return App\\Models\\User but returns App\\Models\\User\|null\.$#'
+			message: '#^Method App\\Filament\\App\\Pages\\EditTeam\:\:user\(\) should return App\\Models\\User but returns App\\Models\\Customer\|App\\Models\\User\|App\\Models\\Vendor\|null\.$#'
 			identifier: return.type
 			count: 1
 			path: app/Filament/App/Pages/EditTeam.php
@@ -470,6 +476,12 @@ parameters:
 
 		-
 			message: '#^Access to an undefined property App\\Filament\\App\\Pages\\NotificationSettings\:\:\$form\.$#'
+			identifier: property.notFound
+			count: 1
+			path: app/Filament/App/Pages/NotificationSettings.php
+
+		-
+			message: '#^Access to an undefined property App\\Models\\Customer\|App\\Models\\User\|App\\Models\\Vendor\:\:\$notificationPreference\.$#'
 			identifier: property.notFound
 			count: 1
 			path: app/Filament/App/Pages/NotificationSettings.php
@@ -535,7 +547,7 @@ parameters:
 			path: app/Filament/App/Pages/PersonalAccessTokensPage.php
 
 		-
-			message: '#^Property App\\Filament\\App\\Pages\\PersonalAccessTokensPage\:\:\$user \(App\\Models\\User\) does not accept App\\Models\\User\|null\.$#'
+			message: '#^Property App\\Filament\\App\\Pages\\PersonalAccessTokensPage\:\:\$user \(App\\Models\\User\) does not accept App\\Models\\Customer\|App\\Models\\User\|App\\Models\\Vendor\|null\.$#'
 			identifier: assign.propertyType
 			count: 1
 			path: app/Filament/App/Pages/PersonalAccessTokensPage.php
@@ -571,13 +583,13 @@ parameters:
 			path: app/Filament/App/Pages/UpdateProfileInformationPage.php
 
 		-
-			message: '#^Cannot access property \$email on App\\Models\\User\|null\.$#'
+			message: '#^Cannot access property \$email on App\\Models\\Customer\|App\\Models\\User\|App\\Models\\Vendor\|null\.$#'
 			identifier: property.nonObject
 			count: 1
 			path: app/Filament/App/Pages/UpdateProfileInformationPage.php
 
 		-
-			message: '#^Cannot access property \$name on App\\Models\\User\|null\.$#'
+			message: '#^Cannot access property \$name on App\\Models\\Customer\|App\\Models\\User\|App\\Models\\Vendor\|null\.$#'
 			identifier: property.nonObject
 			count: 1
 			path: app/Filament/App/Pages/UpdateProfileInformationPage.php
@@ -589,7 +601,7 @@ parameters:
 			path: app/Filament/App/Pages/UpdateProfileInformationPage.php
 
 		-
-			message: '#^Cannot call method forceFill\(\) on App\\Models\\User\|null\.$#'
+			message: '#^Cannot call method forceFill\(\) on App\\Models\\Customer\|App\\Models\\User\|App\\Models\\Vendor\|null\.$#'
 			identifier: method.nonObject
 			count: 1
 			path: app/Filament/App/Pages/UpdateProfileInformationPage.php
@@ -779,6 +791,12 @@ parameters:
 			identifier: binaryOp.invalid
 			count: 1
 			path: app/Filament/App/Resources/ChartOfAccounts/Pages/ListChartOfAccounts.php
+
+		-
+			message: '#^Call to an undefined method App\\Models\\Customer\|App\\Models\\User\|App\\Models\\Vendor\:\:allTeams\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: app/Filament/App/Resources/ConsolidationGroups/ConsolidationGroupResource.php
 
 		-
 			message: '#^Cannot cast mixed to int\.$#'
@@ -1207,7 +1225,7 @@ parameters:
 			path: app/Http/Controllers/Api/BillController.php
 
 		-
-			message: '#^Cannot access property \$current_team_id on App\\Models\\User\|null\.$#'
+			message: '#^Cannot access property \$current_team_id on App\\Models\\Customer\|App\\Models\\User\|App\\Models\\Vendor\|null\.$#'
 			identifier: property.nonObject
 			count: 4
 			path: app/Http/Controllers/Api/BillController.php
@@ -1243,7 +1261,7 @@ parameters:
 			path: app/Http/Controllers/Api/ChartOfAccountController.php
 
 		-
-			message: '#^Cannot access property \$current_team_id on App\\Models\\User\|null\.$#'
+			message: '#^Cannot access property \$current_team_id on App\\Models\\Customer\|App\\Models\\User\|App\\Models\\Vendor\|null\.$#'
 			identifier: property.nonObject
 			count: 3
 			path: app/Http/Controllers/Api/ChartOfAccountController.php
@@ -1279,7 +1297,7 @@ parameters:
 			path: app/Http/Controllers/Api/EstimateController.php
 
 		-
-			message: '#^Cannot access property \$current_team_id on App\\Models\\User\|null\.$#'
+			message: '#^Cannot access property \$current_team_id on App\\Models\\Customer\|App\\Models\\User\|App\\Models\\Vendor\|null\.$#'
 			identifier: property.nonObject
 			count: 4
 			path: app/Http/Controllers/Api/EstimateController.php
@@ -1327,7 +1345,7 @@ parameters:
 			path: app/Http/Controllers/Api/InvoiceController.php
 
 		-
-			message: '#^Cannot access property \$current_team_id on App\\Models\\User\|null\.$#'
+			message: '#^Cannot access property \$current_team_id on App\\Models\\Customer\|App\\Models\\User\|App\\Models\\Vendor\|null\.$#'
 			identifier: property.nonObject
 			count: 4
 			path: app/Http/Controllers/Api/InvoiceController.php
@@ -1399,13 +1417,13 @@ parameters:
 			path: app/Http/Controllers/Api/JournalEntryController.php
 
 		-
-			message: '#^Cannot access property \$current_team_id on App\\Models\\User\|null\.$#'
+			message: '#^Cannot access property \$current_team_id on App\\Models\\Customer\|App\\Models\\User\|App\\Models\\Vendor\|null\.$#'
 			identifier: property.nonObject
 			count: 4
 			path: app/Http/Controllers/Api/JournalEntryController.php
 
 		-
-			message: '#^Cannot access property \$id on App\\Models\\User\|null\.$#'
+			message: '#^Cannot access property \$id on App\\Models\\Customer\|App\\Models\\User\|App\\Models\\Vendor\|null\.$#'
 			identifier: property.nonObject
 			count: 1
 			path: app/Http/Controllers/Api/JournalEntryController.php
@@ -1609,13 +1627,13 @@ parameters:
 			path: app/Http/Controllers/Api/PlaidController.php
 
 		-
-			message: '#^Cannot access property \$current_team_id on App\\Models\\User\|null\.$#'
+			message: '#^Cannot access property \$current_team_id on App\\Models\\Customer\|App\\Models\\User\|App\\Models\\Vendor\|null\.$#'
 			identifier: property.nonObject
 			count: 1
 			path: app/Http/Controllers/Api/PlaidController.php
 
 		-
-			message: '#^Cannot access property \$id on App\\Models\\User\|null\.$#'
+			message: '#^Cannot access property \$id on App\\Models\\Customer\|App\\Models\\User\|App\\Models\\Vendor\|null\.$#'
 			identifier: property.nonObject
 			count: 5
 			path: app/Http/Controllers/Api/PlaidController.php
@@ -1753,14 +1771,20 @@ parameters:
 			path: app/Http/Controllers/Api/QboController.php
 
 		-
-			message: '#^Cannot access property \$current_team_id on App\\Models\\User\|null\.$#'
+			message: '#^Cannot access property \$current_team_id on App\\Models\\Customer\|App\\Models\\User\|App\\Models\\Vendor\|null\.$#'
 			identifier: property.nonObject
 			count: 1
 			path: app/Http/Controllers/Api/QboController.php
 
 		-
-			message: '#^Cannot access property \$id on App\\Models\\User\|null\.$#'
+			message: '#^Cannot access property \$id on App\\Models\\Customer\|App\\Models\\User\|App\\Models\\Vendor\|null\.$#'
 			identifier: property.nonObject
+			count: 1
+			path: app/Http/Controllers/Api/QboController.php
+
+		-
+			message: '#^Cannot cast mixed to int\.$#'
+			identifier: cast.int
 			count: 1
 			path: app/Http/Controllers/Api/QboController.php
 
@@ -1786,6 +1810,12 @@ parameters:
 			message: '#^Access to an undefined property App\\Models\\BankConnection\:\:\$team_id\.$#'
 			identifier: property.notFound
 			count: 5
+			path: app/Http/Controllers/Api/RevolutController.php
+
+		-
+			message: '#^Access to an undefined property App\\Models\\Customer\|App\\Models\\User\|App\\Models\\Vendor\:\:\$id\.$#'
+			identifier: property.notFound
+			count: 2
 			path: app/Http/Controllers/Api/RevolutController.php
 
 		-
@@ -1843,13 +1873,13 @@ parameters:
 			path: app/Http/Controllers/Api/RevolutController.php
 
 		-
-			message: '#^Cannot access property \$current_team_id on App\\Models\\User\|null\.$#'
+			message: '#^Cannot access property \$current_team_id on App\\Models\\Customer\|App\\Models\\User\|App\\Models\\Vendor\|null\.$#'
 			identifier: property.nonObject
 			count: 1
 			path: app/Http/Controllers/Api/RevolutController.php
 
 		-
-			message: '#^Cannot access property \$id on App\\Models\\User\|null\.$#'
+			message: '#^Cannot access property \$id on App\\Models\\Customer\|App\\Models\\User\|App\\Models\\Vendor\|null\.$#'
 			identifier: property.nonObject
 			count: 3
 			path: app/Http/Controllers/Api/RevolutController.php
@@ -1981,13 +2011,13 @@ parameters:
 			path: app/Http/Controllers/Api/SageController.php
 
 		-
-			message: '#^Cannot access property \$current_team_id on App\\Models\\User\|null\.$#'
+			message: '#^Cannot access property \$current_team_id on App\\Models\\Customer\|App\\Models\\User\|App\\Models\\Vendor\|null\.$#'
 			identifier: property.nonObject
 			count: 1
 			path: app/Http/Controllers/Api/SageController.php
 
 		-
-			message: '#^Cannot access property \$id on App\\Models\\User\|null\.$#'
+			message: '#^Cannot access property \$id on App\\Models\\Customer\|App\\Models\\User\|App\\Models\\Vendor\|null\.$#'
 			identifier: property.nonObject
 			count: 1
 			path: app/Http/Controllers/Api/SageController.php
@@ -2005,14 +2035,20 @@ parameters:
 			path: app/Http/Controllers/Api/TransactionController.php
 
 		-
-			message: '#^Cannot access property \$current_team_id on App\\Models\\User\|null\.$#'
+			message: '#^Cannot access property \$current_team_id on App\\Models\\Customer\|App\\Models\\User\|App\\Models\\Vendor\|null\.$#'
 			identifier: property.nonObject
 			count: 1
 			path: app/Http/Controllers/Api/TransactionController.php
 
 		-
-			message: '#^Cannot access property \$id on App\\Models\\User\|null\.$#'
+			message: '#^Cannot access property \$id on App\\Models\\Customer\|App\\Models\\User\|App\\Models\\Vendor\|null\.$#'
 			identifier: property.nonObject
+			count: 1
+			path: app/Http/Controllers/Api/TransactionController.php
+
+		-
+			message: '#^Cannot cast mixed to int\.$#'
+			identifier: cast.int
 			count: 1
 			path: app/Http/Controllers/Api/TransactionController.php
 
@@ -2038,6 +2074,12 @@ parameters:
 			message: '#^Access to an undefined property App\\Models\\BankConnection\:\:\$team_id\.$#'
 			identifier: property.notFound
 			count: 3
+			path: app/Http/Controllers/Api/WiseController.php
+
+		-
+			message: '#^Access to an undefined property App\\Models\\Customer\|App\\Models\\User\|App\\Models\\Vendor\:\:\$id\.$#'
+			identifier: property.notFound
+			count: 2
 			path: app/Http/Controllers/Api/WiseController.php
 
 		-
@@ -2095,13 +2137,13 @@ parameters:
 			path: app/Http/Controllers/Api/WiseController.php
 
 		-
-			message: '#^Cannot access property \$current_team_id on App\\Models\\User\|null\.$#'
+			message: '#^Cannot access property \$current_team_id on App\\Models\\Customer\|App\\Models\\User\|App\\Models\\Vendor\|null\.$#'
 			identifier: property.nonObject
 			count: 1
 			path: app/Http/Controllers/Api/WiseController.php
 
 		-
-			message: '#^Cannot access property \$id on App\\Models\\User\|null\.$#'
+			message: '#^Cannot access property \$id on App\\Models\\Customer\|App\\Models\\User\|App\\Models\\Vendor\|null\.$#'
 			identifier: property.nonObject
 			count: 3
 			path: app/Http/Controllers/Api/WiseController.php
@@ -2245,13 +2287,13 @@ parameters:
 			path: app/Http/Controllers/Api/XeroController.php
 
 		-
-			message: '#^Cannot access property \$current_team_id on App\\Models\\User\|null\.$#'
+			message: '#^Cannot access property \$current_team_id on App\\Models\\Customer\|App\\Models\\User\|App\\Models\\Vendor\|null\.$#'
 			identifier: property.nonObject
 			count: 1
 			path: app/Http/Controllers/Api/XeroController.php
 
 		-
-			message: '#^Cannot access property \$id on App\\Models\\User\|null\.$#'
+			message: '#^Cannot access property \$id on App\\Models\\Customer\|App\\Models\\User\|App\\Models\\Vendor\|null\.$#'
 			identifier: property.nonObject
 			count: 1
 			path: app/Http/Controllers/Api/XeroController.php
@@ -2279,6 +2321,30 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: app/Http/Controllers/LoginController.php
+
+		-
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$password\.$#'
+			identifier: property.notFound
+			count: 1
+			path: app/Http/Controllers/PortalAccessController.php
+
+		-
+			message: '#^Call to an undefined method Illuminate\\Database\\Eloquent\\Model\:\:notify\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: app/Http/Controllers/PortalAccessController.php
+
+		-
+			message: '#^Call to an undefined method Illuminate\\Http\\RedirectResponse\|Illuminate\\Routing\\Redirector\:\:with\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: app/Http/Controllers/PortalAccessController.php
+
+		-
+			message: '#^Cannot cast mixed to string\.$#'
+			identifier: cast.string
+			count: 1
+			path: app/Http/Controllers/PortalAccessController.php
 
 		-
 			message: '#^Access to an undefined property App\\Models\\Team\|Illuminate\\Database\\Eloquent\\Collection\<int, App\\Models\\Team\>\:\:\$id\.$#'
@@ -2383,13 +2449,13 @@ parameters:
 			path: app/Http/Middleware/RedirectIfAuthenticated.php
 
 		-
-			message: '#^Cannot call method getRoleNames\(\) on App\\Models\\User\|null\.$#'
+			message: '#^Cannot call method getRoleNames\(\) on App\\Models\\Customer\|App\\Models\\User\|App\\Models\\Vendor\|null\.$#'
 			identifier: method.nonObject
 			count: 1
 			path: app/Http/Middleware/RedirectIfAuthenticated.php
 
 		-
-			message: '#^Cannot call method hasRole\(\) on App\\Models\\User\|null\.$#'
+			message: '#^Cannot call method hasRole\(\) on App\\Models\\Customer\|App\\Models\\User\|App\\Models\\Vendor\|null\.$#'
 			identifier: method.nonObject
 			count: 1
 			path: app/Http/Middleware/RedirectIfAuthenticated.php
@@ -2431,13 +2497,13 @@ parameters:
 			path: app/Http/Middleware/RoleBasedRedirect.php
 
 		-
-			message: '#^Cannot call method getRoleNames\(\) on App\\Models\\User\|null\.$#'
+			message: '#^Cannot call method getRoleNames\(\) on App\\Models\\Customer\|App\\Models\\User\|App\\Models\\Vendor\|null\.$#'
 			identifier: method.nonObject
 			count: 1
 			path: app/Http/Middleware/RoleBasedRedirect.php
 
 		-
-			message: '#^Cannot call method hasRole\(\) on App\\Models\\User\|null\.$#'
+			message: '#^Cannot call method hasRole\(\) on App\\Models\\Customer\|App\\Models\\User\|App\\Models\\Vendor\|null\.$#'
 			identifier: method.nonObject
 			count: 1
 			path: app/Http/Middleware/RoleBasedRedirect.php
@@ -2509,9 +2575,27 @@ parameters:
 			path: app/Http/Middleware/ScreeningDataEncryptor.php
 
 		-
+			message: '#^Access to an undefined property App\\Models\\Customer\|App\\Models\\User\|App\\Models\\Vendor\:\:\$currentTeam\.$#'
+			identifier: property.notFound
+			count: 1
+			path: app/Http/Middleware/TeamsPermission.php
+
+		-
 			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
 			identifier: property.notFound
 			count: 2
+			path: app/Http/Middleware/TeamsPermission.php
+
+		-
+			message: '#^Call to an undefined method App\\Models\\Customer\|App\\Models\\User\|App\\Models\\Vendor\:\:hasAnyRole\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: app/Http/Middleware/TeamsPermission.php
+
+		-
+			message: '#^Call to an undefined method App\\Models\\Customer\|App\\Models\\User\|App\\Models\\Vendor\:\:hasRole\(\)\.$#'
+			identifier: method.notFound
+			count: 1
 			path: app/Http/Middleware/TeamsPermission.php
 
 		-
@@ -2720,6 +2804,12 @@ parameters:
 
 		-
 			message: '#^Access to an undefined property App\\Models\\Account\:\:\$team_id\.$#'
+			identifier: property.notFound
+			count: 1
+			path: app/Models/Account.php
+
+		-
+			message: '#^Access to an undefined property App\\Models\\Customer\|App\\Models\\User\|App\\Models\\Vendor\:\:\$currentTeam\.$#'
 			identifier: property.notFound
 			count: 1
 			path: app/Models/Account.php
@@ -2996,6 +3086,12 @@ parameters:
 
 		-
 			message: '#^Access to an undefined property App\\Models\\BankConnection\:\:\$team_id\.$#'
+			identifier: property.notFound
+			count: 1
+			path: app/Models/BankConnection.php
+
+		-
+			message: '#^Access to an undefined property App\\Models\\Customer\|App\\Models\\User\|App\\Models\\Vendor\:\:\$currentTeam\.$#'
 			identifier: property.notFound
 			count: 1
 			path: app/Models/BankConnection.php
@@ -4981,6 +5077,12 @@ parameters:
 			path: app/Models/InvoiceItem.php
 
 		-
+			message: '#^Access to an undefined property App\\Models\\Customer\|App\\Models\\User\|App\\Models\\Vendor\:\:\$currentTeam\.$#'
+			identifier: property.notFound
+			count: 2
+			path: app/Models/JournalEntry.php
+
+		-
 			message: '#^Access to an undefined property App\\Models\\JournalEntry\:\:\$lines\.$#'
 			identifier: property.notFound
 			count: 2
@@ -5951,6 +6053,12 @@ parameters:
 			identifier: missingType.generics
 			count: 1
 			path: app/Models/TimeEntry.php
+
+		-
+			message: '#^Access to an undefined property App\\Models\\Customer\|App\\Models\\User\|App\\Models\\Vendor\:\:\$currentTeam\.$#'
+			identifier: property.notFound
+			count: 1
+			path: app/Models/Transaction.php
 
 		-
 			message: '#^Access to an undefined property App\\Models\\Transaction\:\:\$currency\.$#'
@@ -7531,6 +7639,24 @@ parameters:
 			path: app/Notifications/PaymentReminderNotification.php
 
 		-
+			message: '#^Cannot access property \$password on mixed\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: app/Notifications/PortalAccessNotification.php
+
+		-
+			message: '#^Cannot call method getKey\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: app/Notifications/PortalAccessNotification.php
+
+		-
+			message: '#^Cannot cast mixed to string\.$#'
+			identifier: cast.string
+			count: 1
+			path: app/Notifications/PortalAccessNotification.php
+
+		-
 			message: '#^Access to an undefined property App\\Models\\Invoice\:\:\$invoice_id\.$#'
 			identifier: property.notFound
 			count: 1
@@ -8299,6 +8425,12 @@ parameters:
 			path: app/Services/BudgetService.php
 
 		-
+			message: '#^Method App\\Services\\BudgetService\:\:scopedTeamId\(\) should return int but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Services/BudgetService.php
+
+		-
 			message: '#^Parameter \#1 \$callback of method Illuminate\\Database\\Eloquent\\Collection\<int,App\\Models\\Budget\>\:\:map\(\) contains unresolvable type\.$#'
 			identifier: argument.unresolvableType
 			count: 1
@@ -8507,6 +8639,12 @@ parameters:
 			identifier: nullsafe.neverNull
 			count: 1
 			path: app/Services/ExchangeRateService.php
+
+		-
+			message: '#^Access to an undefined property App\\Models\\Customer\|App\\Models\\User\|App\\Models\\Vendor\:\:\$current_team_id\.$#'
+			identifier: property.notFound
+			count: 1
+			path: app/Services/FinancialStatementService.php
 
 		-
 			message: '#^Binary operation "\+" between \(array\|float\|int\) and mixed results in an error\.$#'
@@ -8721,6 +8859,12 @@ parameters:
 		-
 			message: '#^Method App\\Services\\GeneralLedgerService\:\:getTrialBalance\(\) has parameter \$date with no type specified\.$#'
 			identifier: missingType.parameter
+			count: 1
+			path: app/Services/GeneralLedgerService.php
+
+		-
+			message: '#^Method App\\Services\\GeneralLedgerService\:\:scopedTeamId\(\) should return int but returns mixed\.$#'
+			identifier: return.type
 			count: 1
 			path: app/Services/GeneralLedgerService.php
 
@@ -9353,6 +9497,12 @@ parameters:
 			identifier: method.nonObject
 			count: 2
 			path: app/Services/InventoryPostingService.php
+
+		-
+			message: '#^Access to an undefined property App\\Models\\Customer\|App\\Models\\User\|App\\Models\\Vendor\:\:\$current_team_id\.$#'
+			identifier: property.notFound
+			count: 1
+			path: app/Services/InventoryService.php
 
 		-
 			message: '#^Access to an undefined property App\\Models\\Transaction\:\:\$id\.$#'

--- a/resources/views/portal/forgot.blade.php
+++ b/resources/views/portal/forgot.blade.php
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Portal access</title>
+</head>
+<body style="font-family: system-ui, sans-serif; max-width: 24rem; margin: 4rem auto; padding: 0 1rem;">
+    <h1>Portal access</h1>
+
+    @if (session('status'))
+        <p style="color: #15803d;">{{ session('status') }}</p>
+    @endif
+
+    @if ($errors->any())
+        <ul style="color: #b91c1c;">
+            @foreach ($errors->all() as $error)
+                <li>{{ $error }}</li>
+            @endforeach
+        </ul>
+    @endif
+
+    <p>Enter your email and we'll send a link to set your password.</p>
+    <form method="POST" action="{{ $action }}">
+        @csrf
+        <p>
+            <label>Email<br>
+                <input type="email" name="email" required autocomplete="email" style="width:100%">
+            </label>
+        </p>
+        <button type="submit">Email me a link</button>
+    </form>
+</body>
+</html>

--- a/resources/views/portal/set-password.blade.php
+++ b/resources/views/portal/set-password.blade.php
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Set your password</title>
+</head>
+<body style="font-family: system-ui, sans-serif; max-width: 24rem; margin: 4rem auto; padding: 0 1rem;">
+    <h1>Set your password</h1>
+
+    @if ($errors->any())
+        <ul style="color: #b91c1c;">
+            @foreach ($errors->all() as $error)
+                <li>{{ $error }}</li>
+            @endforeach
+        </ul>
+    @endif
+
+    <form method="POST" action="{{ $action }}">
+        @csrf
+        <p>
+            <label>New password<br>
+                <input type="password" name="password" required autocomplete="new-password" style="width:100%">
+            </label>
+        </p>
+        <p>
+            <label>Confirm password<br>
+                <input type="password" name="password_confirmation" required autocomplete="new-password" style="width:100%">
+            </label>
+        </p>
+        <button type="submit">Set password</button>
+    </form>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Http\Controllers\PortalAccessController;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Support\Facades\Route;
 
@@ -17,3 +18,18 @@ use Illuminate\Support\Facades\Route;
 */
 
 Route::get('/', fn (): Factory|\Illuminate\Contracts\View\View => view('home'))->name('home');
+
+// Portal access (customer + vendor): signed-link set-password + forgot. The
+// guard is fixed per route via defaults('guard', ...) — never from user input.
+foreach (['customer' => 'portal', 'vendor' => 'vendor-portal'] as $portalGuard => $portalPath) {
+    Route::prefix($portalPath)->name("portal.{$portalGuard}.")->group(function () use ($portalGuard): void {
+        Route::get('set-password/{id}', [PortalAccessController::class, 'showSetPassword'])
+            ->defaults('guard', $portalGuard)->middleware('signed')->name('set-password');
+        Route::post('set-password/{id}', [PortalAccessController::class, 'setPassword'])
+            ->defaults('guard', $portalGuard)->middleware('signed')->name('set-password.store');
+        Route::get('forgot', [PortalAccessController::class, 'showForgot'])
+            ->defaults('guard', $portalGuard)->name('forgot');
+        Route::post('forgot', [PortalAccessController::class, 'sendForgot'])
+            ->defaults('guard', $portalGuard)->middleware('throttle:6,1')->name('forgot.send');
+    });
+}

--- a/tests/Feature/Portal/PortalAccessTest.php
+++ b/tests/Feature/Portal/PortalAccessTest.php
@@ -38,11 +38,18 @@ class PortalAccessTest extends TestCase
         $this->assertTrue($staff->canAccessPanel(Filament::getPanel('app')));
     }
 
+    private function setPasswordUrl(Customer $customer): string
+    {
+        return URL::temporarySignedRoute('portal.customer.set-password', now()->addHour(), [
+            'id' => $customer->id,
+            'hash' => sha1((string) $customer->password),
+        ]);
+    }
+
     public function test_signed_link_sets_password_and_enables_login(): void
     {
         $customer = Customer::factory()->create();
-
-        $url = URL::temporarySignedRoute('portal.customer.set-password', now()->addHour(), ['id' => $customer->id]);
+        $url = $this->setPasswordUrl($customer);
 
         $this->get($url)->assertOk();
         $this->post($url, ['password' => 'Str0ng-Passw0rd!', 'password_confirmation' => 'Str0ng-Passw0rd!'])
@@ -56,6 +63,23 @@ class PortalAccessTest extends TestCase
         $this->assertTrue(
             auth()->guard('customer')->attempt(['customer_email' => $customer->customer_email, 'password' => 'Str0ng-Passw0rd!'])
         );
+    }
+
+    public function test_link_is_single_use_once_a_password_is_set(): void
+    {
+        $customer = Customer::factory()->create();
+        $url = $this->setPasswordUrl($customer);
+
+        $this->post($url, ['password' => 'Str0ng-Passw0rd!', 'password_confirmation' => 'Str0ng-Passw0rd!'])
+            ->assertRedirect();
+
+        // The same link now carries a stale password-hash → rejected (no takeover).
+        $this->get($url)->assertForbidden();
+        $this->post($url, ['password' => 'Attacker-Pw-99!', 'password_confirmation' => 'Attacker-Pw-99!'])
+            ->assertForbidden();
+
+        $customer->refresh();
+        $this->assertTrue(Hash::check('Str0ng-Passw0rd!', (string) $customer->password));
     }
 
     public function test_expired_or_tampered_link_is_rejected(): void

--- a/tests/Feature/Portal/PortalAccessTest.php
+++ b/tests/Feature/Portal/PortalAccessTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Portal;
+
+use App\Models\Customer;
+use App\Models\User;
+use App\Models\Vendor;
+use App\Notifications\PortalAccessNotification;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\URL;
+use Tests\TestCase;
+
+class PortalAccessTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_panel_access_is_isolated_per_identity(): void
+    {
+        $customer = Customer::factory()->create();
+        $vendor = Vendor::factory()->create();
+        $staff = User::factory()->create();
+
+        $this->assertTrue($customer->canAccessPanel(Filament::getPanel('customer')));
+        $this->assertFalse($customer->canAccessPanel(Filament::getPanel('vendor')));
+        $this->assertFalse($customer->canAccessPanel(Filament::getPanel('admin')));
+
+        $this->assertTrue($vendor->canAccessPanel(Filament::getPanel('vendor')));
+        $this->assertFalse($vendor->canAccessPanel(Filament::getPanel('customer')));
+
+        // Staff must never reach the external portals.
+        $this->assertFalse($staff->canAccessPanel(Filament::getPanel('customer')));
+        $this->assertFalse($staff->canAccessPanel(Filament::getPanel('vendor')));
+        $this->assertTrue($staff->canAccessPanel(Filament::getPanel('app')));
+    }
+
+    public function test_signed_link_sets_password_and_enables_login(): void
+    {
+        $customer = Customer::factory()->create();
+
+        $url = URL::temporarySignedRoute('portal.customer.set-password', now()->addHour(), ['id' => $customer->id]);
+
+        $this->get($url)->assertOk();
+        $this->post($url, ['password' => 'Str0ng-Passw0rd!', 'password_confirmation' => 'Str0ng-Passw0rd!'])
+            ->assertSessionHasNoErrors()
+            ->assertRedirect();
+
+        $customer->refresh();
+        $this->assertTrue(Hash::check('Str0ng-Passw0rd!', (string) $customer->password));
+
+        // Login uses the non-standard customer_email column via the guard.
+        $this->assertTrue(
+            auth()->guard('customer')->attempt(['customer_email' => $customer->customer_email, 'password' => 'Str0ng-Passw0rd!'])
+        );
+    }
+
+    public function test_expired_or_tampered_link_is_rejected(): void
+    {
+        $customer = Customer::factory()->create();
+
+        $expired = URL::temporarySignedRoute('portal.customer.set-password', now()->subMinute(), ['id' => $customer->id]);
+        $this->get($expired)->assertForbidden();
+
+        $valid = URL::temporarySignedRoute('portal.customer.set-password', now()->addHour(), ['id' => $customer->id]);
+        // Swap the id in the path — signature no longer matches.
+        $tampered = str_replace('/set-password/'.$customer->id, '/set-password/'.($customer->id + 1), $valid);
+        $this->get($tampered)->assertForbidden();
+    }
+
+    public function test_forgot_does_not_enumerate_accounts(): void
+    {
+        Notification::fake();
+        $customer = Customer::factory()->create();
+
+        $known = $this->post(route('portal.customer.forgot.send'), ['email' => $customer->customer_email]);
+        $unknown = $this->post(route('portal.customer.forgot.send'), ['email' => 'nobody@example.com']);
+
+        // Identical outcome regardless of whether the email exists.
+        $known->assertRedirect();
+        $unknown->assertRedirect();
+        $this->assertSame($known->getSession()->get('status'), $unknown->getSession()->get('status'));
+
+        // A link is sent only for the real record.
+        Notification::assertSentTo($customer, PortalAccessNotification::class);
+        Notification::assertSentTimes(PortalAccessNotification::class, 1);
+    }
+}

--- a/tests/Feature/Portal/PortalResourcesTest.php
+++ b/tests/Feature/Portal/PortalResourcesTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Portal;
+
+use App\Filament\Customer\Resources\Invoices\PortalInvoiceResource;
+use App\Filament\Customer\Widgets\PortalBalanceWidget;
+use App\Filament\Vendor\Resources\Bills\PortalBillResource;
+use App\Models\Bill;
+use App\Models\Customer;
+use App\Models\Invoice;
+use App\Models\Vendor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PortalResourcesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_customer_sees_only_their_own_invoices(): void
+    {
+        $a = Customer::factory()->create();
+        $b = Customer::factory()->create();
+        $mine = Invoice::factory()->create(['customer_id' => $a->id]);
+        $theirs = Invoice::factory()->create(['customer_id' => $b->id]);
+
+        $this->actingAs($a, 'customer');
+        $ids = PortalInvoiceResource::getEloquentQuery()->pluck('id')->all();
+
+        $this->assertContains($mine->id, $ids);
+        $this->assertNotContains($theirs->id, $ids);
+    }
+
+    public function test_vendor_sees_only_their_own_bills(): void
+    {
+        $a = Vendor::factory()->create();
+        $b = Vendor::factory()->create();
+        $mine = Bill::factory()->create(['vendor_id' => $a->vendor_id]);
+        $theirs = Bill::factory()->create(['vendor_id' => $b->vendor_id]);
+
+        $this->actingAs($a, 'vendor');
+        $ids = PortalBillResource::getEloquentQuery()->pluck('bill_id')->all();
+
+        $this->assertContains($mine->bill_id, $ids);
+        $this->assertNotContains($theirs->bill_id, $ids);
+    }
+
+    public function test_portal_resources_are_read_only(): void
+    {
+        $invoice = Invoice::factory()->create();
+
+        $this->assertFalse(PortalInvoiceResource::canCreate());
+        $this->assertFalse(PortalInvoiceResource::canEdit($invoice));
+        $this->assertFalse(PortalInvoiceResource::canDelete($invoice));
+        $this->assertFalse(PortalBillResource::canCreate());
+    }
+
+    public function test_customer_balance_widget_sums_only_unpaid_own_invoices(): void
+    {
+        $a = Customer::factory()->create();
+        $b = Customer::factory()->create();
+        Invoice::factory()->create(['customer_id' => $a->id, 'payment_status' => 'pending', 'total_amount' => 100]);
+        Invoice::factory()->create(['customer_id' => $a->id, 'payment_status' => 'pending', 'total_amount' => 50]);
+        Invoice::factory()->create(['customer_id' => $a->id, 'payment_status' => 'paid', 'total_amount' => 999]);
+        Invoice::factory()->create(['customer_id' => $b->id, 'payment_status' => 'pending', 'total_amount' => 777]);
+
+        $this->actingAs($a, 'customer');
+
+        $method = new \ReflectionMethod(PortalBalanceWidget::class, 'getStats');
+        $method->setAccessible(true);
+        $stats = $method->invoke(new PortalBalanceWidget);
+
+        // First stat = outstanding balance: own unpaid only (100 + 50), never 999 (paid) or 777 (other customer).
+        $this->assertSame('150.00', $stats[0]->getValue());
+    }
+}


### PR DESCRIPTION
## What

External self-service portals so customers and vendors can log in and view their own documents. Previously `Customer` was `Authenticatable` in name only (no `customer` guard configured, no `password` column) and `Vendor` was a plain model.

## How

**Two guard-isolated Filament portal panels** (no tenancy — the auth identity *is* the scope):
- **Customer** (`/portal`, guard `customer`) — read-only own invoices, outstanding-balance widget, invoice PDF download.
- **Vendor** (`/vendor-portal`, guard `vendor`) — read-only own bills + vendor-credits, balance widget.

**Auth foundation:** `customer`/`vendor` guards + providers; `Vendor` made `Authenticatable`; `password`/`remember_token` columns (+ nullable-unique `vendors.email` so login is unambiguous). `canAccessPanel` strictly isolates each identity to its own panel — staff can't reach the portals, customers/vendors can't reach staff panels.

**Access (invite + set-password + forgot) via signed links** — no password broker (sidesteps the `customer_email` non-standard column and staff-email collisions). Staff trigger a "Send portal invite" action; the link is **signed, expiring, and single-use** (bound to `sha1(password)`, so it dies once a password is set — a leaked/replayed link can't take over). Forgot-password emails the same link to the account's own address, throttled, with no account enumeration. Custom customer login maps the form email to `customer_email`.

**Deferred (YAGNI):** online payment (no gateway), profile edit, statements, cash-flow-specific niceties.

## Security

External auth, so isolation is the priority and is heavily tested. An adversarial security review (34 tool-uses) found **no critical/high issues**; its findings were folded in:
- signed link made single-use (no takeover from a leaked link);
- PDF action re-verifies ownership (defence in depth);
- staff invite action implemented (was spec-required).

## Tests / verification

- 9 portal tests (`tests/Feature/Portal/`): panel-access isolation, cross-account query isolation (customer/vendor), read-only enforcement, balance-widget scoping, signed set-password + login, **single-use link**, expired/tampered rejection, forgot non-enumeration.
- **Full suite green: SQLite (507) and MySQL** (auth-column migrations + unique index verified on MySQL).
- **PHPStan (larastan, level max) clean.**

Design spec: `docs/superpowers/specs/2026-07-04-customer-vendor-portals-design.md`.