### PR TITLE
feat: procurement chains — request→approval→PO (P2-4)

### DIFF
--- a/app/Filament/App/Resources/ApprovalRules/ApprovalRuleResource.php
+++ b/app/Filament/App/Resources/ApprovalRules/ApprovalRuleResource.php
@@ -54,6 +54,7 @@ class ApprovalRuleResource extends Resource
             'Bill' => 'Bill',
             'Expense' => 'Expense',
             'JournalEntry' => 'Journal Entry',
+            'PurchaseRequest' => 'Purchase Request',
         ];
     }
 

--- a/app/Filament/App/Resources/PurchaseRequests/Pages/CreatePurchaseRequest.php
+++ b/app/Filament/App/Resources/PurchaseRequests/Pages/CreatePurchaseRequest.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\App\Resources\PurchaseRequests\Pages;
+
+use App\Filament\App\Resources\PurchaseRequests\PurchaseRequestResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreatePurchaseRequest extends CreateRecord
+{
+    #[\Override]
+    protected static string $resource = PurchaseRequestResource::class;
+}

--- a/app/Filament/App/Resources/PurchaseRequests/Pages/EditPurchaseRequest.php
+++ b/app/Filament/App/Resources/PurchaseRequests/Pages/EditPurchaseRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\App\Resources\PurchaseRequests\Pages;
+
+use App\Filament\App\Resources\PurchaseRequests\PurchaseRequestResource;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+
+class EditPurchaseRequest extends EditRecord
+{
+    #[\Override]
+    protected static string $resource = PurchaseRequestResource::class;
+
+    #[\Override]
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/App/Resources/PurchaseRequests/Pages/ListPurchaseRequests.php
+++ b/app/Filament/App/Resources/PurchaseRequests/Pages/ListPurchaseRequests.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\App\Resources\PurchaseRequests\Pages;
+
+use App\Filament\App\Resources\PurchaseRequests\PurchaseRequestResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListPurchaseRequests extends ListRecords
+{
+    #[\Override]
+    protected static string $resource = PurchaseRequestResource::class;
+
+    #[\Override]
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/App/Resources/PurchaseRequests/PurchaseRequestResource.php
+++ b/app/Filament/App/Resources/PurchaseRequests/PurchaseRequestResource.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\App\Resources\PurchaseRequests;
+
+use App\Filament\App\Resources\PurchaseRequests\Pages\CreatePurchaseRequest;
+use App\Filament\App\Resources\PurchaseRequests\Pages\EditPurchaseRequest;
+use App\Filament\App\Resources\PurchaseRequests\Pages\ListPurchaseRequests;
+use App\Models\PurchaseRequest;
+use App\Services\ProcurementService;
+use Filament\Actions\Action;
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\Repeater;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Notifications\Notification;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+
+class PurchaseRequestResource extends Resource
+{
+    #[\Override]
+    protected static ?string $model = PurchaseRequest::class;
+
+    #[\Override]
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-clipboard-document-list';
+
+    #[\Override]
+    public static function form(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Select::make('supplier_id')
+                    ->relationship('supplier', 'supplier_first_name')
+                    ->required(),
+                DatePicker::make('request_date')
+                    ->required(),
+                TextInput::make('total_amount')
+                    ->numeric()
+                    ->required(),
+                Select::make('status')
+                    ->options([
+                        'draft' => 'Draft',
+                        'submitted' => 'Submitted',
+                        'cancelled' => 'Cancelled',
+                    ])
+                    ->required(),
+                Select::make('approval_status')
+                    ->options([
+                        'pending' => 'Pending',
+                        'approved' => 'Approved',
+                        'rejected' => 'Rejected',
+                    ])
+                    ->disabled()
+                    ->dehydrated(false),
+                Repeater::make('items')
+                    ->relationship()
+                    ->schema([
+                        TextInput::make('description')
+                            ->required(),
+                        TextInput::make('quantity')
+                            ->numeric()
+                            ->required(),
+                        TextInput::make('unit_price')
+                            ->numeric()
+                            ->required(),
+                    ])
+                    ->columns(3),
+                Textarea::make('notes'),
+            ]);
+    }
+
+    #[\Override]
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('request_number')
+                    ->searchable(),
+                TextColumn::make('request_date')
+                    ->date(),
+                TextColumn::make('total_amount')
+                    ->money(),
+                TextColumn::make('approval_status')
+                    ->badge()
+                    ->color(fn (string $state): string => match ($state) {
+                        'approved' => 'success',
+                        'rejected' => 'danger',
+                        default => 'warning',
+                    }),
+            ])
+            ->filters([
+                SelectFilter::make('approval_status')
+                    ->options([
+                        'pending' => 'Pending',
+                        'approved' => 'Approved',
+                        'rejected' => 'Rejected',
+                    ]),
+            ])
+            ->recordActions([
+                Action::make('submitForApproval')
+                    ->label('Submit for approval')
+                    ->requiresConfirmation()
+                    ->visible(fn (PurchaseRequest $record): bool => $record->approval_status !== 'approved')
+                    ->action(function (PurchaseRequest $record): void {
+                        try {
+                            $record->submitForApproval();
+                            Notification::make()->title('Submitted for approval')->success()->send();
+                        } catch (\Throwable) {
+                            Notification::make()->title('Could not submit. Please retry.')->danger()->send();
+                        }
+                    }),
+                Action::make('convertToPurchaseOrder')
+                    ->label('Convert to Purchase Order')
+                    ->requiresConfirmation()
+                    ->visible(fn (PurchaseRequest $record): bool => $record->approval_status === 'approved' && ! $record->purchaseOrder()->exists())
+                    ->action(function (PurchaseRequest $record): void {
+                        try {
+                            app(ProcurementService::class)->createPurchaseOrderFromRequest($record);
+                            Notification::make()->title('Purchase order created')->success()->send();
+                        } catch (\DomainException $e) {
+                            Notification::make()->title($e->getMessage())->danger()->send();
+                        } catch (\Throwable) {
+                            Notification::make()->title('Could not create the purchase order. Please retry.')->danger()->send();
+                        }
+                    }),
+                EditAction::make(),
+                DeleteAction::make(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    #[\Override]
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListPurchaseRequests::route('/'),
+            'create' => CreatePurchaseRequest::route('/create'),
+            'edit' => EditPurchaseRequest::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Models/PurchaseOrder.php
+++ b/app/Models/PurchaseOrder.php
@@ -26,6 +26,7 @@ class PurchaseOrder extends Model
         'status',
         'notes',
         'purchase_request_id',
+        'team_id',
     ];
 
     #[\Override]
@@ -70,6 +71,6 @@ class PurchaseOrder extends Model
 
         $number = $lastPo ? (int) substr((string) $lastPo->po_number, -4) + 1 : 1;
 
-        return $prefix.$year.str_pad($number, 4, '0', STR_PAD_LEFT);
+        return $prefix.$year.str_pad((string) $number, 4, '0', STR_PAD_LEFT);
     }
 }

--- a/app/Models/PurchaseOrder.php
+++ b/app/Models/PurchaseOrder.php
@@ -25,6 +25,7 @@ class PurchaseOrder extends Model
         'total_amount',
         'status',
         'notes',
+        'purchase_request_id',
     ];
 
     #[\Override]
@@ -37,6 +38,11 @@ class PurchaseOrder extends Model
     public function supplier()
     {
         return $this->belongsTo(Supplier::class, 'supplier_id');
+    }
+
+    public function purchaseRequest()
+    {
+        return $this->belongsTo(PurchaseRequest::class, 'purchase_request_id');
     }
 
     public function items()

--- a/app/Models/PurchaseRequest.php
+++ b/app/Models/PurchaseRequest.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types=1);
+namespace App\Models;
+
+use App\Concerns\Approvable;
+use App\Traits\IsTenantModel;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+
+class PurchaseRequest extends Model
+{
+    use Approvable;
+    use HasFactory;
+    use IsTenantModel;
+
+    #[\Override]
+    protected $fillable = [
+        'supplier_id', 'request_number', 'request_date', 'total_amount',
+        'status', 'notes', 'team_id',
+        'approval_status', 'approved_by', 'approved_at', 'rejection_reason',
+    ];
+
+    #[\Override]
+    protected $casts = [
+        'request_date' => 'date',
+        'total_amount' => 'decimal:2',
+        'approved_at' => 'datetime',
+    ];
+
+    #[\Override]
+    protected static function boot(): void
+    {
+        parent::boot();
+        static::creating(function (PurchaseRequest $request): void {
+            if (empty($request->team_id) && ($team = auth()->user()?->currentTeam) !== null) {
+                $request->team_id = $team->getKey();
+            }
+            if (empty($request->request_number)) {
+                $request->request_number = 'PR-'.str_pad((string) ((int) static::max('id') + 1), 6, '0', STR_PAD_LEFT);
+            }
+        });
+    }
+
+    public function approvalAmount(): float
+    {
+        return (float) $this->total_amount;
+    }
+
+    public function supplier(): BelongsTo { return $this->belongsTo(Supplier::class, 'supplier_id', 'supplier_id'); }
+    public function items(): HasMany { return $this->hasMany(PurchaseRequestItem::class); }
+    public function purchaseOrder(): HasOne { return $this->hasOne(PurchaseOrder::class, 'purchase_request_id'); }
+}

--- a/app/Models/PurchaseRequestItem.php
+++ b/app/Models/PurchaseRequestItem.php
@@ -1,5 +1,7 @@
 <?php
+
 declare(strict_types=1);
+
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -22,5 +24,23 @@ class PurchaseRequestItem extends Model
         'total_price' => 'decimal:2',
     ];
 
-    public function purchaseRequest(): BelongsTo { return $this->belongsTo(PurchaseRequest::class); }
+    #[\Override]
+    protected static function boot(): void
+    {
+        parent::boot();
+
+        // The create form captures quantity + unit_price but not the line total, so
+        // derive it when absent — otherwise items save with total_price = 0 and that
+        // zero propagates into the converted purchase order's line items.
+        static::saving(function (PurchaseRequestItem $item): void {
+            if (empty($item->total_price)) {
+                $item->total_price = (float) $item->quantity * (float) $item->unit_price;
+            }
+        });
+    }
+
+    public function purchaseRequest(): BelongsTo
+    {
+        return $this->belongsTo(PurchaseRequest::class);
+    }
 }

--- a/app/Models/PurchaseRequestItem.php
+++ b/app/Models/PurchaseRequestItem.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class PurchaseRequestItem extends Model
+{
+    use HasFactory;
+
+    #[\Override]
+    protected $fillable = [
+        'purchase_request_id', 'description', 'quantity', 'unit_price', 'total_price',
+    ];
+
+    #[\Override]
+    protected $casts = [
+        'quantity' => 'integer',
+        'unit_price' => 'decimal:2',
+        'total_price' => 'decimal:2',
+    ];
+
+    public function purchaseRequest(): BelongsTo { return $this->belongsTo(PurchaseRequest::class); }
+}

--- a/app/Services/ProcurementService.php
+++ b/app/Services/ProcurementService.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+namespace App\Services;
+
+use App\Models\PurchaseOrder;
+use App\Models\PurchaseRequest;
+use Illuminate\Support\Facades\DB;
+
+class ProcurementService
+{
+    public function createPurchaseOrderFromRequest(PurchaseRequest $request): PurchaseOrder
+    {
+        if ($request->approval_status !== 'approved') {
+            throw new \DomainException('Only an approved purchase request can become a purchase order.');
+        }
+        if ($request->purchaseOrder()->exists()) {
+            throw new \DomainException('This request already has a purchase order.');
+        }
+
+        return DB::transaction(function () use ($request): PurchaseOrder {
+            $po = PurchaseOrder::create([
+                'supplier_id' => $request->supplier_id,
+                'purchase_request_id' => $request->id,
+                'po_number' => PurchaseOrder::generatePoNumber(),
+                'order_date' => today(),
+                'status' => 'draft',
+                'total_amount' => $request->total_amount,
+                'team_id' => $request->team_id,
+            ]);
+
+            foreach ($request->items as $item) {
+                $po->items()->create([
+                    'description' => $item->description,
+                    'quantity' => $item->quantity,
+                    'unit_price' => $item->unit_price,
+                    'total_price' => $item->total_price,
+                ]);
+            }
+
+            return $po;
+        });
+    }
+}

--- a/database/migrations/2026_07_06_100001_create_purchase_requests_table.php
+++ b/database/migrations/2026_07_06_100001_create_purchase_requests_table.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void {
+        Schema::create('purchase_requests', function (Blueprint $t): void {
+            $t->id();
+            $t->foreignId('supplier_id')->nullable()->constrained('suppliers', 'supplier_id')->nullOnDelete();
+            $t->string('request_number')->unique();
+            $t->date('request_date');
+            $t->decimal('total_amount', 15, 2)->default(0);
+            $t->string('status')->default('draft');
+            $t->text('notes')->nullable();
+            $t->string('approval_status')->default('pending');
+            $t->foreignId('approved_by')->nullable();
+            $t->timestamp('approved_at')->nullable();
+            $t->text('rejection_reason')->nullable();
+            $t->foreignId('team_id')->nullable();
+            $t->timestamps();
+        });
+    }
+    public function down(): void { Schema::dropIfExists('purchase_requests'); }
+};

--- a/database/migrations/2026_07_06_100002_create_purchase_request_items_table.php
+++ b/database/migrations/2026_07_06_100002_create_purchase_request_items_table.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void {
+        Schema::create('purchase_request_items', function (Blueprint $t): void {
+            $t->id();
+            $t->foreignId('purchase_request_id')->constrained('purchase_requests')->cascadeOnDelete();
+            $t->string('description')->nullable();
+            $t->integer('quantity')->default(1);
+            $t->decimal('unit_price', 15, 2)->default(0);
+            $t->decimal('total_price', 15, 2)->default(0);
+            $t->timestamps();
+        });
+    }
+    public function down(): void { Schema::dropIfExists('purchase_request_items'); }
+};

--- a/database/migrations/2026_07_06_100003_add_purchase_request_id_to_purchase_orders_table.php
+++ b/database/migrations/2026_07_06_100003_add_purchase_request_id_to_purchase_orders_table.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void {
+        Schema::table('purchase_orders', function (Blueprint $t): void {
+            $t->foreignId('purchase_request_id')->nullable()->unique()->after('purchase_order_id')
+                ->constrained('purchase_requests')->nullOnDelete();
+        });
+    }
+    public function down(): void {
+        Schema::table('purchase_orders', function (Blueprint $t): void {
+            $t->dropConstrainedForeignId('purchase_request_id');
+        });
+    }
+};

--- a/docs/superpowers/plans/2026-07-04-procurement-chains.md
+++ b/docs/superpowers/plans/2026-07-04-procurement-chains.md
@@ -1,0 +1,592 @@
+# Procurement Chains Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `PurchaseRequest` (requisition) that runs through the existing approval engine and, once approved, converts to a `PurchaseOrder`.
+
+**Architecture:** New `PurchaseRequest` + `PurchaseRequestItem` models (default `id` PK, `IsTenantModel`, `Approvable`). Approval + spend control reuse the existing `Approvable` engine (`submitForApproval()` → `ApprovalRule` amount thresholds). A `ProcurementService` converts an approved request to a `PurchaseOrder` (approved-only, once-per-request), copying supplier + items + total and linking `purchase_orders.purchase_request_id`. Mirrors the just-shipped sales-order lifecycle.
+
+**Tech Stack:** Laravel 13 / PHP 8.5 / Filament 5 / PHPUnit (sqlite `:memory:`). Tests from repo root: `docker compose exec -T php-fpm php artisan test --filter=<Name>` (no host php; php-fpm mounts `./src` at `/var/www`; if "service not running": `docker compose up -d php-fpm`, wait 2s, retry).
+
+## Global Constraints
+
+- `declare(strict_types=1);` on every new PHP file; `#[\Override]` on overrides.
+- New models use `App\Traits\IsTenantModel` + a `creating` hook stamping `team_id` from `auth()->user()?->currentTeam` when empty.
+- Money columns `decimal(15,2)`. Copy amounts verbatim across the conversion.
+- `PurchaseRequest` implements `Approvable::approvalAmount(): float` returning `(float) $this->total_amount`; it needs the approval columns (`approval_status`, `approved_by`, `approved_at`, `rejection_reason`) — same set `bills`/`invoices` have.
+- Tests: sqlite `:memory:` ENFORCES FKs; `Model::unguard()` is global. No `TeamFactory` — `Team::forceCreate(['user_id'=>$u->id,'name'=>'X','personal_team'=>false])`. `invoices.team_id`/similar have real FKs, but `purchase_requests.team_id`/`purchase_orders` do not constrain team_id, so arbitrary ints are fine there.
+- Commit after each task; Conventional-Commits subject ≤50 chars.
+
+---
+
+### Task 1: PurchaseRequest + PurchaseRequestItem models, migrations, PO link
+
+**Files:**
+- Create: `src/database/migrations/2026_07_06_100001_create_purchase_requests_table.php`
+- Create: `src/database/migrations/2026_07_06_100002_create_purchase_request_items_table.php`
+- Create: `src/database/migrations/2026_07_06_100003_add_purchase_request_id_to_purchase_orders_table.php`
+- Create: `src/app/Models/PurchaseRequest.php`
+- Create: `src/app/Models/PurchaseRequestItem.php`
+- Modify: `src/app/Models/PurchaseOrder.php` (fillable + `purchaseRequest()` relation)
+- Test: `src/tests/Feature/Procurement/PurchaseRequestModelTest.php`
+
+**Interfaces:**
+- Produces: `PurchaseRequest` (PK `id`; fillable `supplier_id, request_number, request_date, total_amount, status, notes, team_id, approval_status, approved_by, approved_at, rejection_reason`; `use Approvable, IsTenantModel`; `approvalAmount(): float`; relations `supplier()`, `items()` = `hasMany(PurchaseRequestItem)`, `purchaseOrder()` = `hasOne(PurchaseOrder, 'purchase_request_id')`). `PurchaseRequestItem` (fillable `purchase_request_id, description, quantity, unit_price, total_price`). `PurchaseOrder::purchaseRequest(): BelongsTo`.
+
+- [ ] **Step 1: Write the failing test**
+
+```php
+<?php // src/tests/Feature/Procurement/PurchaseRequestModelTest.php
+declare(strict_types=1);
+namespace Tests\Feature\Procurement;
+
+use App\Models\PurchaseRequest;
+use App\Models\PurchaseRequestItem;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PurchaseRequestModelTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_request_persists_with_items_and_generates_number(): void
+    {
+        $request = PurchaseRequest::create([
+            'request_date' => '2026-07-01', 'status' => 'draft', 'total_amount' => 100,
+        ]);
+        PurchaseRequestItem::create([
+            'purchase_request_id' => $request->id, 'description' => 'Widget',
+            'quantity' => 1, 'unit_price' => 100, 'total_price' => 100,
+        ]);
+
+        $this->assertNotEmpty($request->request_number);
+        $this->assertCount(1, $request->fresh()->items);
+        $this->assertSame(100.0, $request->approvalAmount());
+    }
+}
+```
+
+- [ ] **Step 2: Run it, verify it fails**
+
+Run: `docker compose exec -T php-fpm php artisan test --filter=PurchaseRequestModelTest`
+Expected: FAIL (`App\Models\PurchaseRequest` not found).
+
+- [ ] **Step 3: Create the migrations**
+
+```php
+<?php // 2026_07_06_100001_create_purchase_requests_table.php
+declare(strict_types=1);
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+return new class extends Migration {
+    public function up(): void {
+        Schema::create('purchase_requests', function (Blueprint $t): void {
+            $t->id();
+            $t->foreignId('supplier_id')->nullable()->constrained('suppliers', 'supplier_id')->nullOnDelete();
+            $t->string('request_number')->unique();
+            $t->date('request_date');
+            $t->decimal('total_amount', 15, 2)->default(0);
+            $t->string('status')->default('draft');
+            $t->text('notes')->nullable();
+            $t->string('approval_status')->default('pending');
+            $t->foreignId('approved_by')->nullable();
+            $t->timestamp('approved_at')->nullable();
+            $t->text('rejection_reason')->nullable();
+            $t->foreignId('team_id')->nullable();
+            $t->timestamps();
+        });
+    }
+    public function down(): void { Schema::dropIfExists('purchase_requests'); }
+};
+```
+
+```php
+<?php // 2026_07_06_100002_create_purchase_request_items_table.php
+declare(strict_types=1);
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+return new class extends Migration {
+    public function up(): void {
+        Schema::create('purchase_request_items', function (Blueprint $t): void {
+            $t->id();
+            $t->foreignId('purchase_request_id')->constrained('purchase_requests')->cascadeOnDelete();
+            $t->string('description')->nullable();
+            $t->integer('quantity')->default(1);
+            $t->decimal('unit_price', 15, 2)->default(0);
+            $t->decimal('total_price', 15, 2)->default(0);
+            $t->timestamps();
+        });
+    }
+    public function down(): void { Schema::dropIfExists('purchase_request_items'); }
+};
+```
+
+```php
+<?php // 2026_07_06_100003_add_purchase_request_id_to_purchase_orders_table.php
+declare(strict_types=1);
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+return new class extends Migration {
+    public function up(): void {
+        Schema::table('purchase_orders', function (Blueprint $t): void {
+            $t->foreignId('purchase_request_id')->nullable()->unique()->after('purchase_order_id')
+                ->constrained('purchase_requests')->nullOnDelete();
+        });
+    }
+    public function down(): void {
+        Schema::table('purchase_orders', function (Blueprint $t): void {
+            $t->dropConstrainedForeignId('purchase_request_id');
+        });
+    }
+};
+```
+
+- [ ] **Step 4: Create the models**
+
+```php
+<?php // src/app/Models/PurchaseRequest.php
+declare(strict_types=1);
+namespace App\Models;
+use App\Concerns\Approvable;
+use App\Traits\IsTenantModel;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+
+class PurchaseRequest extends Model
+{
+    use Approvable;
+    use HasFactory;
+    use IsTenantModel;
+
+    #[\Override]
+    protected $fillable = [
+        'supplier_id', 'request_number', 'request_date', 'total_amount',
+        'status', 'notes', 'team_id',
+        'approval_status', 'approved_by', 'approved_at', 'rejection_reason',
+    ];
+
+    #[\Override]
+    protected $casts = [
+        'request_date' => 'date',
+        'total_amount' => 'decimal:2',
+        'approved_at' => 'datetime',
+    ];
+
+    #[\Override]
+    protected static function boot(): void
+    {
+        parent::boot();
+        static::creating(function (PurchaseRequest $request): void {
+            if (empty($request->team_id) && ($team = auth()->user()?->currentTeam) !== null) {
+                $request->team_id = $team->getKey();
+            }
+            if (empty($request->request_number)) {
+                $request->request_number = 'PR-'.str_pad((string) ((int) static::max('id') + 1), 6, '0', STR_PAD_LEFT);
+            }
+        });
+    }
+
+    public function approvalAmount(): float
+    {
+        return (float) $this->total_amount;
+    }
+
+    public function supplier(): BelongsTo { return $this->belongsTo(Supplier::class, 'supplier_id', 'supplier_id'); }
+    public function items(): HasMany { return $this->hasMany(PurchaseRequestItem::class); }
+    public function purchaseOrder(): HasOne { return $this->hasOne(PurchaseOrder::class, 'purchase_request_id'); }
+}
+```
+
+```php
+<?php // src/app/Models/PurchaseRequestItem.php
+declare(strict_types=1);
+namespace App\Models;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class PurchaseRequestItem extends Model
+{
+    use HasFactory;
+
+    #[\Override]
+    protected $fillable = [
+        'purchase_request_id', 'description', 'quantity', 'unit_price', 'total_price',
+    ];
+
+    #[\Override]
+    protected $casts = [
+        'quantity' => 'integer',
+        'unit_price' => 'decimal:2',
+        'total_price' => 'decimal:2',
+    ];
+
+    public function purchaseRequest(): BelongsTo { return $this->belongsTo(PurchaseRequest::class); }
+}
+```
+
+- [ ] **Step 5: Wire the PurchaseOrder relation**
+
+In `src/app/Models/PurchaseOrder.php`: add `'purchase_request_id',` to `$fillable`, and add:
+
+```php
+public function purchaseRequest()
+{
+    return $this->belongsTo(PurchaseRequest::class, 'purchase_request_id');
+}
+```
+
+- [ ] **Step 6: Run the test, verify it passes**
+
+Run: `docker compose exec -T php-fpm php artisan test --filter=PurchaseRequestModelTest`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git -C src add app/Models/PurchaseRequest.php app/Models/PurchaseRequestItem.php app/Models/PurchaseOrder.php database/migrations/2026_07_06_1000*.php tests/Feature/Procurement/PurchaseRequestModelTest.php
+git -C src commit -m "feat(procurement): PurchaseRequest models + PO link"
+```
+
+---
+
+### Task 2: Approval / spend-control wiring
+
+**Files:**
+- Modify: `src/app/Filament/App/Resources/ApprovalRules/ApprovalRuleResource.php:53-56` (add `PurchaseRequest` option)
+- Test: `src/tests/Feature/Procurement/PurchaseRequestApprovalTest.php`
+
+**Interfaces:**
+- Consumes: `PurchaseRequest` (Task 1), the existing `Approvable::submitForApproval()` + `App\Models\ApprovalRule`.
+- Produces: nothing new — verifies that `submitForApproval()` auto-approves a request when no spend rule matches and routes to `pending` when a threshold rule applies.
+
+- [ ] **Step 1: Write the failing test**
+
+```php
+<?php // src/tests/Feature/Procurement/PurchaseRequestApprovalTest.php
+declare(strict_types=1);
+namespace Tests\Feature\Procurement;
+
+use App\Models\ApprovalRule;
+use App\Models\PurchaseRequest;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PurchaseRequestApprovalTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_request_auto_approves_when_no_spend_rule_matches(): void
+    {
+        $request = PurchaseRequest::create(['request_date' => '2026-07-01', 'total_amount' => 500, 'status' => 'draft']);
+
+        $request->submitForApproval();
+
+        $this->assertSame('approved', $request->fresh()->approval_status);
+    }
+
+    public function test_request_over_threshold_routes_to_pending(): void
+    {
+        $user = User::factory()->create();
+        $team = Team::forceCreate(['user_id' => $user->id, 'name' => 'Acme', 'personal_team' => false]);
+        ApprovalRule::create([
+            'team_id' => $team->id, 'approvable_type' => 'PurchaseRequest',
+            'min_amount' => 100, 'steps' => ['manager'], 'is_active' => true,
+        ]);
+
+        $request = PurchaseRequest::create([
+            'request_date' => '2026-07-01', 'total_amount' => 500, 'status' => 'draft', 'team_id' => $team->id,
+        ]);
+
+        $request->submitForApproval();
+
+        $this->assertSame('pending', $request->fresh()->approval_status);
+    }
+}
+```
+
+- [ ] **Step 2: Run it, verify it fails or passes**
+
+Run: `docker compose exec -T php-fpm php artisan test --filter=PurchaseRequestApprovalTest`
+Expected: the first test PASSES already (no rule → auto-approve is trait behavior). The second may FAIL if `ApprovalRule::create` needs columns you must match — read `app/Models/ApprovalRule.php` `$fillable` and the `approval_rules` migration, and adjust the `create([...])` keys in the test to the real column names (e.g. `steps` may be a JSON/cast column named differently). Fix the test to match the real schema, then it should pass. If `submitForApproval()`'s `matchFor` compares `class_basename` (`PurchaseRequest`), the `approvable_type` value `'PurchaseRequest'` is correct.
+
+- [ ] **Step 3: Register the type option**
+
+In `ApprovalRuleResource.php`, in `approvableTypeOptions()`, add after `'JournalEntry' => 'Journal Entry',`:
+
+```php
+            'PurchaseRequest' => 'Purchase Request',
+```
+
+- [ ] **Step 4: Run the tests, verify they pass**
+
+Run: `docker compose exec -T php-fpm php artisan test --filter=PurchaseRequestApprovalTest`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C src add app/Filament/App/Resources/ApprovalRules/ApprovalRuleResource.php tests/Feature/Procurement/PurchaseRequestApprovalTest.php
+git -C src commit -m "feat(procurement): route requests through approval"
+```
+
+---
+
+### Task 3: ProcurementService::createPurchaseOrderFromRequest
+
+**Files:**
+- Create: `src/app/Services/ProcurementService.php`
+- Test: `src/tests/Feature/Procurement/CreatePurchaseOrderTest.php`
+
+**Interfaces:**
+- Consumes: `PurchaseRequest`, `PurchaseRequestItem` (Task 1), `PurchaseOrder`, `PurchaseOrderItem`.
+- Produces: `ProcurementService::createPurchaseOrderFromRequest(PurchaseRequest $request): PurchaseOrder` — throws `\DomainException` when the request is not `approved` (approval_status) or already has a purchase order. Copies `supplier_id`, `total_amount`; each `PurchaseRequestItem` (`description, quantity, unit_price, total_price`) → `PurchaseOrderItem`; sets PO `status='draft'`, `order_date=today()`, `po_number=PurchaseOrder::generatePoNumber()`, `purchase_request_id`, `team_id`. Returns the persisted `PurchaseOrder`.
+
+- [ ] **Step 1: Write the failing test**
+
+```php
+<?php // src/tests/Feature/Procurement/CreatePurchaseOrderTest.php
+declare(strict_types=1);
+namespace Tests\Feature\Procurement;
+
+use App\Models\PurchaseRequest;
+use App\Models\PurchaseRequestItem;
+use App\Services\ProcurementService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CreatePurchaseOrderTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function approvedRequest(): PurchaseRequest
+    {
+        $request = PurchaseRequest::create([
+            'request_date' => '2026-07-01', 'total_amount' => 300,
+            'status' => 'draft', 'approval_status' => 'approved', 'team_id' => 7,
+        ]);
+        PurchaseRequestItem::create([
+            'purchase_request_id' => $request->id, 'description' => 'Steel',
+            'quantity' => 3, 'unit_price' => 100, 'total_price' => 300,
+        ]);
+        return $request;
+    }
+
+    public function test_approved_request_converts_to_purchase_order(): void
+    {
+        $request = $this->approvedRequest();
+        $po = app(ProcurementService::class)->createPurchaseOrderFromRequest($request);
+
+        $this->assertSame($request->id, $po->purchase_request_id);
+        $this->assertSame('300.00', (string) $po->total_amount);
+        $this->assertSame('draft', $po->status);
+        $this->assertNotEmpty($po->po_number);
+        $this->assertSame(7, (int) $po->team_id);
+        $this->assertCount(1, $po->items);
+        $this->assertSame('Steel', $po->items->first()->description);
+    }
+
+    public function test_unapproved_request_is_rejected(): void
+    {
+        $request = $this->approvedRequest();
+        $request->update(['approval_status' => 'pending']);
+
+        $this->expectException(\DomainException::class);
+        app(ProcurementService::class)->createPurchaseOrderFromRequest($request);
+    }
+
+    public function test_request_cannot_convert_twice(): void
+    {
+        $request = $this->approvedRequest();
+        app(ProcurementService::class)->createPurchaseOrderFromRequest($request);
+
+        $this->expectException(\DomainException::class);
+        app(ProcurementService::class)->createPurchaseOrderFromRequest($request->fresh());
+    }
+}
+```
+
+- [ ] **Step 2: Run it, verify it fails**
+
+Run: `docker compose exec -T php-fpm php artisan test --filter=CreatePurchaseOrderTest`
+Expected: FAIL (`App\Services\ProcurementService` not found).
+
+- [ ] **Step 3: Implement the service**
+
+```php
+<?php // src/app/Services/ProcurementService.php
+declare(strict_types=1);
+namespace App\Services;
+
+use App\Models\PurchaseOrder;
+use App\Models\PurchaseRequest;
+use Illuminate\Support\Facades\DB;
+
+class ProcurementService
+{
+    public function createPurchaseOrderFromRequest(PurchaseRequest $request): PurchaseOrder
+    {
+        if ($request->approval_status !== 'approved') {
+            throw new \DomainException('Only an approved purchase request can become a purchase order.');
+        }
+        if ($request->purchaseOrder()->exists()) {
+            throw new \DomainException('This request already has a purchase order.');
+        }
+
+        return DB::transaction(function () use ($request): PurchaseOrder {
+            $po = PurchaseOrder::create([
+                'supplier_id' => $request->supplier_id,
+                'purchase_request_id' => $request->id,
+                'po_number' => PurchaseOrder::generatePoNumber(),
+                'order_date' => today(),
+                'status' => 'draft',
+                'total_amount' => $request->total_amount,
+                'team_id' => $request->team_id,
+            ]);
+
+            foreach ($request->items as $item) {
+                $po->items()->create([
+                    'description' => $item->description,
+                    'quantity' => $item->quantity,
+                    'unit_price' => $item->unit_price,
+                    'total_price' => $item->total_price,
+                ]);
+            }
+
+            return $po;
+        });
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests, verify they pass**
+
+Run: `docker compose exec -T php-fpm php artisan test --filter=CreatePurchaseOrderTest`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C src add app/Services/ProcurementService.php tests/Feature/Procurement/CreatePurchaseOrderTest.php
+git -C src commit -m "feat(procurement): convert approved request to PO"
+```
+
+---
+
+### Task 4: Filament PurchaseRequestResource + submit/convert actions
+
+**Files:**
+- Create: `src/app/Filament/App/Resources/PurchaseRequests/PurchaseRequestResource.php`
+- Create: `src/app/Filament/App/Resources/PurchaseRequests/Pages/{ListPurchaseRequests,CreatePurchaseRequest,EditPurchaseRequest}.php`
+- Test: `src/tests/Feature/Procurement/PurchaseRequestTenancyTest.php`
+
+**Interfaces:**
+- Consumes: `ProcurementService` (Task 3), `PurchaseRequest` (Task 1), `Approvable::submitForApproval()`.
+- Produces: a team-scoped Filament resource with two row actions — `submitForApproval` (visible when `approval_status !== 'approved'`) calling `$record->submitForApproval()`, and `convertToPurchaseOrder` (visible when `approval_status === 'approved'` and no PO yet) calling `ProcurementService::createPurchaseOrderFromRequest`, each wrapped in `try { … } catch (\DomainException $e) { danger notification($e->getMessage()) } catch (\Throwable) { danger notification('…') }`.
+
+- [ ] **Step 1: Write the failing test (tenancy stamp)**
+
+```php
+<?php // src/tests/Feature/Procurement/PurchaseRequestTenancyTest.php
+declare(strict_types=1);
+namespace Tests\Feature\Procurement;
+
+use App\Models\PurchaseRequest;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PurchaseRequestTenancyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_request_stamps_actor_team_on_create(): void
+    {
+        $user = User::factory()->create();
+        $team = Team::forceCreate(['user_id' => $user->id, 'name' => 'Acme', 'personal_team' => false]);
+        $user->forceFill(['current_team_id' => $team->id])->save();
+        $this->actingAs($user);
+
+        $request = PurchaseRequest::create(['request_date' => '2026-07-01', 'total_amount' => 10, 'status' => 'draft']);
+
+        $this->assertSame($team->id, (int) $request->team_id);
+    }
+}
+```
+
+- [ ] **Step 2: Run it, verify it passes**
+
+Run: `docker compose exec -T php-fpm php artisan test --filter=PurchaseRequestTenancyTest`
+Expected: PASS (Task 1's `creating` hook stamps `team_id`). Keep it as a guard.
+
+- [ ] **Step 3: Build the Filament resource**
+
+Read an existing app-panel resource first — `src/app/Filament/App/Resources/PurchaseOrders/PurchaseOrderResource.php` and its `Pages/` — and mirror its exact Filament v5 API (schema/form, table, `getPages`, `recordActions`, `#[\Override]`, navigation). Create `PurchaseRequestResource` (`$model = PurchaseRequest::class`, tenant-scoped by default). Table: `request_number`, `request_date`, `total_amount` (money), `approval_status` (badge). Two row actions:
+
+```php
+\Filament\Actions\Action::make('submitForApproval')
+    ->label('Submit for approval')
+    ->requiresConfirmation()
+    ->visible(fn (\App\Models\PurchaseRequest $r): bool => $r->approval_status !== 'approved')
+    ->action(function (\App\Models\PurchaseRequest $r): void {
+        try {
+            $r->submitForApproval();
+            \Filament\Notifications\Notification::make()->title('Submitted for approval')->success()->send();
+        } catch (\Throwable) {
+            \Filament\Notifications\Notification::make()->title('Could not submit. Please retry.')->danger()->send();
+        }
+    }),
+\Filament\Actions\Action::make('convertToPurchaseOrder')
+    ->label('Convert to Purchase Order')
+    ->requiresConfirmation()
+    ->visible(fn (\App\Models\PurchaseRequest $r): bool => $r->approval_status === 'approved' && ! $r->purchaseOrder()->exists())
+    ->action(function (\App\Models\PurchaseRequest $r): void {
+        try {
+            app(\App\Services\ProcurementService::class)->createPurchaseOrderFromRequest($r);
+            \Filament\Notifications\Notification::make()->title('Purchase order created')->success()->send();
+        } catch (\DomainException $e) {
+            \Filament\Notifications\Notification::make()->title($e->getMessage())->danger()->send();
+        } catch (\Throwable) {
+            \Filament\Notifications\Notification::make()->title('Could not create the purchase order. Please retry.')->danger()->send();
+        }
+    }),
+```
+
+Make the `approval_status` form field read-only (`->disabled()->dehydrated(false)`) — it is system-managed by the approval engine. Create the three Pages (List/Create/Edit) mirroring an existing resource's Pages.
+
+- [ ] **Step 4: Run all procurement tests, verify they pass**
+
+Run: `docker compose exec -T php-fpm php artisan test --filter=Procurement`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C src add app/Filament/App/Resources/PurchaseRequests tests/Feature/Procurement/PurchaseRequestTenancyTest.php
+git -C src commit -m "feat(procurement): Filament request resource + actions"
+```
+
+---
+
+## Integration (after all tasks)
+
+- Full suite sqlite: `docker compose exec -T php-fpm php artisan test`.
+- MySQL masking check: `docker compose exec -T -e DB_CONNECTION=mysql -e DB_HOST=mysql -e DB_PORT=3306 -e DB_DATABASE=accounting_test -e DB_USERNAME=homestead -e DB_PASSWORD=secret php-fpm php artisan test --filter=Procurement`.
+- PHPStan: `docker compose exec -T php-fpm ./vendor/bin/phpstan analyse --no-progress --memory-limit=1G`; regenerate the frozen baseline if only Filament/Eloquent-`mixed` idiom errors remain.
+- Pint the new files.
+- Adversarial review focus: convert guard bypass (unapproved / already-converted), spend-control bypass (converting a request that skipped `submitForApproval`), tenancy stamping on the created PO, item/total copy correctness, and whether the `approval_status` field is truly system-managed (not hand-editable to `approved`).
+
+## Self-Review
+
+- **Spec coverage:** PurchaseRequest + item models ✓ (T1); Approvable + approvalAmount ✓ (T1); spend control via ApprovalRule thresholds + type option ✓ (T2); approved-only + once convert with `purchase_request_id` link + unique index ✓ (T3 + T1 migration); supplier/items/total copy ✓ (T3); Filament resource + submit + convert actions + system-managed status ✓ (T4); tenancy ✓ (T4 test + T1 hook); PO→Bill untouched ✓. Deferred (goods receipt / 3-way match) intentionally absent.
+- **Placeholders:** none — each step has real code/commands. T2 Step 2 asks the implementer to reconcile the test's `ApprovalRule::create` keys with the real `approval_rules` schema because that table was built in P1-1 and its exact column names (esp. the `steps` cast) must be matched, not guessed.
+- **Type consistency:** `createPurchaseOrderFromRequest(PurchaseRequest): PurchaseOrder` used identically in T3/T4; `purchaseOrder()` (hasOne) / `purchaseRequest()` (belongsTo) relation names consistent; `PurchaseRequestItem` uses `total_price` (matching `PurchaseOrderItem`), copied verbatim in T3.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5449,6 +5449,12 @@ parameters:
 			path: app/Models/PurchaseOrder.php
 
 		-
+			message: '#^Method App\\Models\\PurchaseOrder\:\:purchaseRequest\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Models/PurchaseOrder.php
+
+		-
 			message: '#^Method App\\Models\\PurchaseOrder\:\:supplier\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -5467,12 +5473,6 @@ parameters:
 			path: app/Models/PurchaseOrder.php
 
 		-
-			message: '#^Parameter \#1 \$string of function str_pad expects string, int given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/Models/PurchaseOrder.php
-
-		-
 			message: '#^Class App\\Models\\PurchaseOrderItem uses generic trait Illuminate\\Database\\Eloquent\\Factories\\HasFactory but does not specify its types\: TFactory$#'
 			identifier: missingType.generics
 			count: 1
@@ -5483,6 +5483,72 @@ parameters:
 			identifier: missingType.return
 			count: 1
 			path: app/Models/PurchaseOrderItem.php
+
+		-
+			message: '#^Access to an undefined property App\\Models\\Customer\|App\\Models\\User\|App\\Models\\Vendor\:\:\$currentTeam\.$#'
+			identifier: property.notFound
+			count: 1
+			path: app/Models/PurchaseRequest.php
+
+		-
+			message: '#^Cannot cast mixed to int\.$#'
+			identifier: cast.int
+			count: 1
+			path: app/Models/PurchaseRequest.php
+
+		-
+			message: '#^Class App\\Models\\PurchaseRequest uses generic trait Illuminate\\Database\\Eloquent\\Factories\\HasFactory but does not specify its types\: TFactory$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/PurchaseRequest.php
+
+		-
+			message: '#^Method App\\Models\\PurchaseRequest\:\:approvalRequest\(\) return type with generic class Illuminate\\Database\\Eloquent\\Relations\\MorphOne does not specify its types\: TRelatedModel, TDeclaringModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/PurchaseRequest.php
+
+		-
+			message: '#^Method App\\Models\\PurchaseRequest\:\:items\(\) return type with generic class Illuminate\\Database\\Eloquent\\Relations\\HasMany does not specify its types\: TRelatedModel, TDeclaringModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/PurchaseRequest.php
+
+		-
+			message: '#^Method App\\Models\\PurchaseRequest\:\:purchaseOrder\(\) return type with generic class Illuminate\\Database\\Eloquent\\Relations\\HasOne does not specify its types\: TRelatedModel, TDeclaringModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/PurchaseRequest.php
+
+		-
+			message: '#^Method App\\Models\\PurchaseRequest\:\:supplier\(\) return type with generic class Illuminate\\Database\\Eloquent\\Relations\\BelongsTo does not specify its types\: TRelatedModel, TDeclaringModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/PurchaseRequest.php
+
+		-
+			message: '#^Method App\\Models\\PurchaseRequest\:\:team\(\) return type with generic class Illuminate\\Database\\Eloquent\\Relations\\BelongsTo does not specify its types\: TRelatedModel, TDeclaringModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/PurchaseRequest.php
+
+		-
+			message: '#^Property App\\Models\\PurchaseRequest\:\:\$team_id \(int\<0, max\>\|null\) does not accept mixed\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: app/Models/PurchaseRequest.php
+
+		-
+			message: '#^Class App\\Models\\PurchaseRequestItem uses generic trait Illuminate\\Database\\Eloquent\\Factories\\HasFactory but does not specify its types\: TFactory$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/PurchaseRequestItem.php
+
+		-
+			message: '#^Method App\\Models\\PurchaseRequestItem\:\:purchaseRequest\(\) return type with generic class Illuminate\\Database\\Eloquent\\Relations\\BelongsTo does not specify its types\: TRelatedModel, TDeclaringModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/PurchaseRequestItem.php
 
 		-
 			message: '#^Class App\\Models\\QboConnection uses generic trait Illuminate\\Database\\Eloquent\\Factories\\HasFactory but does not specify its types\: TFactory$#'
@@ -10073,6 +10139,36 @@ parameters:
 			identifier: assign.propertyType
 			count: 1
 			path: app/Services/PlaidService.php
+
+		-
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$description\.$#'
+			identifier: property.notFound
+			count: 1
+			path: app/Services/ProcurementService.php
+
+		-
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$quantity\.$#'
+			identifier: property.notFound
+			count: 1
+			path: app/Services/ProcurementService.php
+
+		-
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$total_price\.$#'
+			identifier: property.notFound
+			count: 1
+			path: app/Services/ProcurementService.php
+
+		-
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$unit_price\.$#'
+			identifier: property.notFound
+			count: 1
+			path: app/Services/ProcurementService.php
+
+		-
+			message: '#^Cannot call method create\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: app/Services/ProcurementService.php
 
 		-
 			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$amount\.$#'

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -23,7 +23,6 @@
         <env name="CACHE_DRIVER" value="array"/>
         <env name="DB_CONNECTION" value="sqlite"/>
         <env name="DB_DATABASE" value=":memory:"/>
-        <env name="DB_FOREIGN_KEYS" value="false"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="PULSE_ENABLED" value="false"/>
         <env name="QUEUE_CONNECTION" value="sync"/>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -23,6 +23,7 @@
         <env name="CACHE_DRIVER" value="array"/>
         <env name="DB_CONNECTION" value="sqlite"/>
         <env name="DB_DATABASE" value=":memory:"/>
+        <env name="DB_FOREIGN_KEYS" value="false"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="PULSE_ENABLED" value="false"/>
         <env name="QUEUE_CONNECTION" value="sync"/>

--- a/tests/Feature/Procurement/CreatePurchaseOrderTest.php
+++ b/tests/Feature/Procurement/CreatePurchaseOrderTest.php
@@ -1,5 +1,8 @@
-<?php // src/tests/Feature/Procurement/CreatePurchaseOrderTest.php
+<?php
+
+// src/tests/Feature/Procurement/CreatePurchaseOrderTest.php
 declare(strict_types=1);
+
 namespace Tests\Feature\Procurement;
 
 use App\Models\PaymentTerm;
@@ -50,6 +53,7 @@ class CreatePurchaseOrderTest extends TestCase
             'purchase_request_id' => $request->id, 'description' => 'Steel',
             'quantity' => 3, 'unit_price' => 100, 'total_price' => 300,
         ]);
+
         return $request;
     }
 
@@ -65,6 +69,22 @@ class CreatePurchaseOrderTest extends TestCase
         $this->assertSame($this->teamId, (int) $po->team_id);
         $this->assertCount(1, $po->items);
         $this->assertSame('Steel', $po->items->first()->description);
+    }
+
+    public function test_line_total_is_derived_and_carried_to_the_purchase_order(): void
+    {
+        $request = $this->approvedRequest();
+        // A UI-created line omits total_price (the form doesn't capture it).
+        PurchaseRequestItem::create([
+            'purchase_request_id' => $request->id, 'description' => 'Bolts',
+            'quantity' => 4, 'unit_price' => 25,
+        ]);
+
+        $po = app(ProcurementService::class)->createPurchaseOrderFromRequest($request);
+
+        $bolts = $po->items->firstWhere('description', 'Bolts');
+        // 4 * 25 = 100, not the default 0.
+        $this->assertSame('100.00', (string) $bolts->total_price);
     }
 
     public function test_unapproved_request_is_rejected(): void

--- a/tests/Feature/Procurement/CreatePurchaseOrderTest.php
+++ b/tests/Feature/Procurement/CreatePurchaseOrderTest.php
@@ -6,6 +6,8 @@ use App\Models\PaymentTerm;
 use App\Models\PurchaseRequest;
 use App\Models\PurchaseRequestItem;
 use App\Models\Supplier;
+use App\Models\Team;
+use App\Models\User;
 use App\Services\ProcurementService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -14,9 +16,16 @@ class CreatePurchaseOrderTest extends TestCase
 {
     use RefreshDatabase;
 
+    private int $teamId;
 
     private function approvedRequest(): PurchaseRequest
     {
+        // purchase_orders.team_id has a real FK to teams — use a real team so the
+        // converted PO inserts under FK enforcement (never disable FKs to pass).
+        $user = User::factory()->create();
+        $team = Team::forceCreate(['user_id' => $user->id, 'name' => 'Acme', 'personal_team' => false]);
+        $this->teamId = $team->id;
+
         $term = PaymentTerm::create([
             'payment_term_name' => 'Net 30',
             'payment_term_description' => 'Net 30 days',
@@ -35,7 +44,7 @@ class CreatePurchaseOrderTest extends TestCase
         $request = PurchaseRequest::create([
             'supplier_id' => $supplier->supplier_id,
             'request_date' => '2026-07-01', 'total_amount' => 300,
-            'status' => 'draft', 'approval_status' => 'approved', 'team_id' => 7,
+            'status' => 'draft', 'approval_status' => 'approved', 'team_id' => $team->id,
         ]);
         PurchaseRequestItem::create([
             'purchase_request_id' => $request->id, 'description' => 'Steel',
@@ -53,7 +62,7 @@ class CreatePurchaseOrderTest extends TestCase
         $this->assertSame('300.00', (string) $po->total_amount);
         $this->assertSame('draft', $po->status);
         $this->assertNotEmpty($po->po_number);
-        $this->assertSame(7, (int) $po->team_id);
+        $this->assertSame($this->teamId, (int) $po->team_id);
         $this->assertCount(1, $po->items);
         $this->assertSame('Steel', $po->items->first()->description);
     }

--- a/tests/Feature/Procurement/CreatePurchaseOrderTest.php
+++ b/tests/Feature/Procurement/CreatePurchaseOrderTest.php
@@ -1,0 +1,78 @@
+<?php // src/tests/Feature/Procurement/CreatePurchaseOrderTest.php
+declare(strict_types=1);
+namespace Tests\Feature\Procurement;
+
+use App\Models\PaymentTerm;
+use App\Models\PurchaseRequest;
+use App\Models\PurchaseRequestItem;
+use App\Models\Supplier;
+use App\Services\ProcurementService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CreatePurchaseOrderTest extends TestCase
+{
+    use RefreshDatabase;
+
+
+    private function approvedRequest(): PurchaseRequest
+    {
+        $term = PaymentTerm::create([
+            'payment_term_name' => 'Net 30',
+            'payment_term_description' => 'Net 30 days',
+            'payment_term_number_of_days' => 30,
+        ]);
+        $supplier = Supplier::create([
+            'payment_term_id' => $term->payment_term_id,
+            'supplier_first_name' => 'Test',
+            'supplier_last_name' => 'Supplier',
+            'supplier_email' => 'supplier@test.com',
+            'supplier_address' => '123 Main St',
+            'supplier_phone_number' => '123-456-7890',
+            'supplier_limit_credit' => 10000,
+            'supplier_tin' => 123456789,
+        ]);
+        $request = PurchaseRequest::create([
+            'supplier_id' => $supplier->supplier_id,
+            'request_date' => '2026-07-01', 'total_amount' => 300,
+            'status' => 'draft', 'approval_status' => 'approved', 'team_id' => 7,
+        ]);
+        PurchaseRequestItem::create([
+            'purchase_request_id' => $request->id, 'description' => 'Steel',
+            'quantity' => 3, 'unit_price' => 100, 'total_price' => 300,
+        ]);
+        return $request;
+    }
+
+    public function test_approved_request_converts_to_purchase_order(): void
+    {
+        $request = $this->approvedRequest();
+        $po = app(ProcurementService::class)->createPurchaseOrderFromRequest($request);
+
+        $this->assertSame($request->id, $po->purchase_request_id);
+        $this->assertSame('300.00', (string) $po->total_amount);
+        $this->assertSame('draft', $po->status);
+        $this->assertNotEmpty($po->po_number);
+        $this->assertSame(7, (int) $po->team_id);
+        $this->assertCount(1, $po->items);
+        $this->assertSame('Steel', $po->items->first()->description);
+    }
+
+    public function test_unapproved_request_is_rejected(): void
+    {
+        $request = $this->approvedRequest();
+        $request->update(['approval_status' => 'pending']);
+
+        $this->expectException(\DomainException::class);
+        app(ProcurementService::class)->createPurchaseOrderFromRequest($request);
+    }
+
+    public function test_request_cannot_convert_twice(): void
+    {
+        $request = $this->approvedRequest();
+        app(ProcurementService::class)->createPurchaseOrderFromRequest($request);
+
+        $this->expectException(\DomainException::class);
+        app(ProcurementService::class)->createPurchaseOrderFromRequest($request->fresh());
+    }
+}

--- a/tests/Feature/Procurement/PurchaseRequestApprovalTest.php
+++ b/tests/Feature/Procurement/PurchaseRequestApprovalTest.php
@@ -1,0 +1,53 @@
+<?php // src/tests/Feature/Procurement/PurchaseRequestApprovalTest.php
+declare(strict_types=1);
+namespace Tests\Feature\Procurement;
+
+use App\Models\ApprovalRule;
+use App\Models\PurchaseRequest;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class PurchaseRequestApprovalTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_request_auto_approves_when_no_spend_rule_matches(): void
+    {
+        // submitForApproval() fails closed without a team (App\Concerns\Approvable::submitForApproval),
+        // so a team is required even for the no-rule-matches path.
+        $user = User::factory()->create();
+        $team = Team::forceCreate(['user_id' => $user->id, 'name' => 'Acme', 'personal_team' => false]);
+
+        $request = PurchaseRequest::create([
+            'request_date' => '2026-07-01', 'total_amount' => 500, 'status' => 'draft', 'team_id' => $team->id,
+        ]);
+
+        $request->submitForApproval();
+
+        $this->assertSame('approved', $request->fresh()->approval_status);
+    }
+
+    public function test_request_over_threshold_routes_to_pending(): void
+    {
+        $user = User::factory()->create();
+        $team = Team::forceCreate(['user_id' => $user->id, 'name' => 'Acme', 'personal_team' => false]);
+        // The first approval step notifies users holding this Spatie role (see
+        // ApprovalRequestedNotification::dispatchToRole), so it must exist first.
+        Role::create(['name' => 'manager', 'guard_name' => 'web']);
+        ApprovalRule::create([
+            'team_id' => $team->id, 'approvable_type' => 'PurchaseRequest',
+            'min_amount' => 100, 'steps' => ['manager'], 'is_active' => true,
+        ]);
+
+        $request = PurchaseRequest::create([
+            'request_date' => '2026-07-01', 'total_amount' => 500, 'status' => 'draft', 'team_id' => $team->id,
+        ]);
+
+        $request->submitForApproval();
+
+        $this->assertSame('pending', $request->fresh()->approval_status);
+    }
+}

--- a/tests/Feature/Procurement/PurchaseRequestModelTest.php
+++ b/tests/Feature/Procurement/PurchaseRequestModelTest.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+namespace Tests\Feature\Procurement;
+
+use App\Models\PurchaseRequest;
+use App\Models\PurchaseRequestItem;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PurchaseRequestModelTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_request_persists_with_items_and_generates_number(): void
+    {
+        $request = PurchaseRequest::create([
+            'request_date' => '2026-07-01', 'status' => 'draft', 'total_amount' => 100,
+        ]);
+        PurchaseRequestItem::create([
+            'purchase_request_id' => $request->id, 'description' => 'Widget',
+            'quantity' => 1, 'unit_price' => 100, 'total_price' => 100,
+        ]);
+
+        $this->assertNotEmpty($request->request_number);
+        $this->assertCount(1, $request->fresh()->items);
+        $this->assertSame(100.0, $request->approvalAmount());
+    }
+}

--- a/tests/Feature/Procurement/PurchaseRequestTenancyTest.php
+++ b/tests/Feature/Procurement/PurchaseRequestTenancyTest.php
@@ -1,0 +1,26 @@
+<?php // src/tests/Feature/Procurement/PurchaseRequestTenancyTest.php
+declare(strict_types=1);
+namespace Tests\Feature\Procurement;
+
+use App\Models\PurchaseRequest;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PurchaseRequestTenancyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_request_stamps_actor_team_on_create(): void
+    {
+        $user = User::factory()->create();
+        $team = Team::forceCreate(['user_id' => $user->id, 'name' => 'Acme', 'personal_team' => false]);
+        $user->forceFill(['current_team_id' => $team->id])->save();
+        $this->actingAs($user);
+
+        $request = PurchaseRequest::create(['request_date' => '2026-07-01', 'total_amount' => 10, 'status' => 'draft']);
+
+        $this->assertSame($team->id, (int) $request->team_id);
+    }
+}


### PR DESCRIPTION
## What

Adds a **PurchaseRequest** (requisition) that runs through the existing approval engine and, once approved, converts to a **PurchaseOrder**. PO→Bill already existed downstream. AP-side mirror of the sales-order lifecycle (#846).

## How

- **`PurchaseRequest` + `PurchaseRequestItem`** models/migrations (default `id` PK, `IsTenantModel`, auto-numbered, `team_id` stamped). `PurchaseRequest use Approvable` with `approvalAmount() = total_amount`.
- **Approval = spend control (reuses P1-1):** `submitForApproval()` → `ApprovalRule::matchFor('PurchaseRequest', total, team)`. No/under-threshold rule → auto-approve; over threshold → routes the role chain. `PurchaseRequest` added to `ApprovalRuleResource`'s type options so spend-limit rules can target it.
- **`ProcurementService::createPurchaseOrderFromRequest`** — guards: `approval_status === 'approved'` and no PO yet (unique `purchase_orders.purchase_request_id` backstop). Copies supplier + total + line items; PO status `draft`.
- **Filament:** `PurchaseRequestResource` — "Submit for approval" + "Convert to Purchase Order" actions (approved+unconverted), `approval_status` read-only (system-managed).

Built plan → subagent-driven TDD (4 tasks) → whole-branch adversarial review.

## Notable (caught + fixed in-branch)

- **Test-integrity:** a Task-3 implementer disabled `DB_FOREIGN_KEYS` suite-wide to dodge a `team_id` FK error — **reverted**; the real fix is a real `Team` in the test (`purchase_orders.team_id` has an FK). FK enforcement (the SQLite-masking guard) is intact.
- **Line totals (final review):** the request form didn't capture item `total_price`, so items saved 0 and that propagated into converted PO line items. Fixed with a `saving` hook deriving `total_price = qty × unit_price` + a regression test.

## Deferred

Goods receipt, three-way match, receiving.

## Tests / verification

- 8 procurement tests (`tests/Feature/Procurement/`): model + number, approval auto/threshold routing, convert guards (approved-only, once), **line-total derivation**, tenancy.
- **Full suite green: SQLite (525) and MySQL** (new migrations + unique indexes verified on MySQL, FK enforcement on).
- **PHPStan (larastan, level max) clean.**

Plan: `docs/superpowers/plans/2026-07-04-procurement-chains.md`.