### PR TITLE
fix(invoice): remove broken approve/reject events (pre-release)

### DIFF
--- a/app/Models/Invoice.php
+++ b/app/Models/Invoice.php
@@ -233,17 +233,11 @@ class Invoice extends Model
     public function approve(): void
     {
         $this->markApproved();
-
-        // Back-compat: pre-existing consumer event, kept firing alongside ApprovableApproved.
-        event(new InvoiceApproved($this));
     }
 
     public function reject(?string $reason): void
     {
         $this->markRejected($reason);
-
-        // Back-compat: pre-existing consumer event, kept firing alongside ApprovableRejected.
-        event(new InvoiceRejected($this));
     }
 
     public function isPending(): bool

--- a/tests/Feature/Invoice/InvoiceApprovalTest.php
+++ b/tests/Feature/Invoice/InvoiceApprovalTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Invoice;
+
+use App\Models\Invoice;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class InvoiceApprovalTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_approve_and_reject_do_not_fatal_and_set_status(): void
+    {
+        $user = User::factory()->create();
+        $team = Team::forceCreate(['user_id' => $user->id, 'name' => 'Acme', 'personal_team' => false]);
+        $user->forceFill(['current_team_id' => $team->id])->save();
+        $this->actingAs($user);
+
+        $approved = Invoice::factory()->create(['team_id' => $team->id]);
+        $approved->approve(); // previously fatal: dispatched a nonexistent InvoiceApproved class
+        $this->assertSame('approved', $approved->fresh()->approval_status);
+
+        $rejected = Invoice::factory()->create(['team_id' => $team->id]);
+        $rejected->reject('duplicate');
+        $this->assertSame('rejected', $rejected->fresh()->approval_status);
+        $this->assertSame('duplicate', $rejected->fresh()->rejection_reason);
+    }
+}


### PR DESCRIPTION
## What

Pre-release fix: `Invoice::approve()` / `reject()` dispatched `App\Models\InvoiceApproved` / `InvoiceRejected` — classes that **don't exist anywhere** in the codebase → a class-not-found **fatal** the moment either method is called.

Discovered during the payment-posting work; confirmed **latent** (no current caller wires the approval UI to these). `markApproved()` / `markRejected()` (from the `Approvable` concern) already fire the real `ApprovableApproved` / `ApprovableRejected` events, and the broken dispatches had **no consumer**. Removed the two dead lines — the methods keep working via the real events.

Regression test added: `approve()`/`reject()` no longer fatal and set `approval_status` to approved/rejected.

## Shield note (investigated, no action needed)

I also checked whether the ~8 new Filament resources/actions shipped this cycle need `shield:generate`. They don't: the app has only **1 policy file total** and runs with `super_admin` bypass — it does not per-resource policy-gate, so the new resources are consistent with the existing 30. Regenerating Shield `--all` would be a risky authz-posture change, out of scope for a release fix.

## Tests

- Invoice + approval group: **82 passed**; full suite green; PHPStan clean; Pint applied.
