### PR TITLE
ci: MySQL parity + prod-boot smoke; fix prod Octane image

### DIFF
--- a/.docker/php.ini
+++ b/.docker/php.ini
@@ -15,7 +15,6 @@ opcache.max_accelerated_files = 32531
 opcache.validate_timestamps = 0
 opcache.file_update_protection = 0
 opcache.interned_strings_buffer = 16
-opcache.file_cache = 60
 
 [JIT]
 opcache.jit_buffer_size = 128M

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,31 @@
+# Keep the build context lean and prod-safe. Notably: the image installs a
+# clean --no-dev vendor/ in the composer-deps stage; without excluding vendor/
+# here, `COPY . .` would clobber it with the host's dev vendor (pail, dev deps,
+# host-arch rr binary) and reintroduce the package:discover boot failure.
+.git
+.gitignore
+.github
+
+# Local env / secrets — the image bakes .env from .env.example itself.
+.env
+.env.*
+!.env.example
+
+# Reinstalled/regenerated inside the image.
+vendor
+node_modules
+bootstrap/cache/*.php
+
+# Generated runtime state.
+storage/logs/*
+storage/framework/cache/data/*
+storage/framework/sessions/*
+storage/framework/views/*
+public/hot
+public/storage
+
+# Dev-only.
+tests
+.idea
+.vscode
+*.log

--- a/.github/workflows/prod-boot-smoke.yml
+++ b/.github/workflows/prod-boot-smoke.yml
@@ -1,0 +1,48 @@
+name: Prod Boot Smoke
+
+# Builds the production Octane/RoadRunner image (the Dockerfile that actually
+# ships — the SQLite test suite never exercises it) and proves the container
+# boots and serves a request. Catches boot-time fatals the unit tests can't:
+# stale committed caches, bad php.ini directives, broken service providers.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  prod-boot:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build production Octane image
+        run: docker build -t accounting-prod:smoke -f Dockerfile .
+
+      - name: Boot container
+        run: |
+          docker run -d --name prodsmoke \
+            -e APP_KEY="base64:$(openssl rand -base64 32)" \
+            -p 8099:80 accounting-prod:smoke
+
+      - name: Wait for /up to return 200
+        run: |
+          code=$(curl -s -o /dev/null -w "%{http_code}" \
+            --retry 30 --retry-delay 2 --retry-connrefused --retry-all-errors \
+            http://127.0.0.1:8099/up)
+          echo "GET /up -> $code"
+          test "$code" = "200"
+
+      - name: Container logs on failure
+        if: failure()
+        run: docker logs prodsmoke || true
+
+      - name: Cleanup
+        if: always()
+        run: docker rm -f prodsmoke || true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,3 +56,66 @@ jobs:
           flags: unittests
           name: codecov-umbrella
           fail_ci_if_error: false
+
+  # Parity run on MySQL. The default suite is SQLite :memory: (phpunit.xml),
+  # which silently masks prod-only failures MySQL enforces — unknown-column
+  # string-literal fallback and VARCHAR overflow have both shipped bugs here.
+  # Real env vars override phpunit.xml's <env> (no force="true"), so this reuses
+  # the same suite against MySQL 8.4.
+  tests-mysql:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    services:
+      mysql:
+        image: mysql:8.4
+        env:
+          MYSQL_ROOT_PASSWORD: secret
+          MYSQL_DATABASE: accounting_test
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -psecret"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.5'
+          extensions: mbstring, pdo, pdo_mysql, bcmath, opcache, zip, gd, intl
+          coverage: none
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Copy environment file
+        run: cp .env.example .env
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist --optimize-autoloader
+
+      - name: Generate application key
+        run: php artisan key:generate
+
+      - name: Run tests against MySQL
+        env:
+          DB_CONNECTION: mysql
+          DB_HOST: 127.0.0.1
+          DB_PORT: 3306
+          DB_DATABASE: accounting_test
+          DB_USERNAME: root
+          DB_PASSWORD: secret
+        run: php artisan test

--- a/app/Http/Middleware/EnsureTwoFactorEnabled.php
+++ b/app/Http/Middleware/EnsureTwoFactorEnabled.php
@@ -20,7 +20,7 @@ use Symfony\Component\HttpFoundation\Response;
 class EnsureTwoFactorEnabled
 {
     /**
-     * @param  \Closure(\Illuminate\Http\Request): \Symfony\Component\HttpFoundation\Response  $next
+     * @param  Closure(Request): Response  $next
      */
     public function handle(Request $request, Closure $next): Response
     {

--- a/app/Models/ApprovalRequest.php
+++ b/app/Models/ApprovalRequest.php
@@ -12,7 +12,9 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 class ApprovalRequest extends Model
 {
     public const STATUS_PENDING = 'pending';
+
     public const STATUS_APPROVED = 'approved';
+
     public const STATUS_REJECTED = 'rejected';
 
     #[\Override]

--- a/app/Models/ApprovalStep.php
+++ b/app/Models/ApprovalStep.php
@@ -10,8 +10,11 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 class ApprovalStep extends Model
 {
     public const STATUS_PENDING = 'pending';
+
     public const STATUS_APPROVED = 'approved';
+
     public const STATUS_REJECTED = 'rejected';
+
     public const STATUS_ESCALATED = 'escalated';
 
     #[\Override]

--- a/app/Models/ForecastScenario.php
+++ b/app/Models/ForecastScenario.php
@@ -1,6 +1,10 @@
-<?php // src/app/Models/ForecastScenario.php
+<?php
+
+// src/app/Models/ForecastScenario.php
 declare(strict_types=1);
+
 namespace App\Models;
+
 use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -25,5 +29,8 @@ class ForecastScenario extends Model
         });
     }
 
-    public function lines(): HasMany { return $this->hasMany(ForecastScenarioLine::class); }
+    public function lines(): HasMany
+    {
+        return $this->hasMany(ForecastScenarioLine::class);
+    }
 }

--- a/app/Models/ForecastScenarioLine.php
+++ b/app/Models/ForecastScenarioLine.php
@@ -1,6 +1,10 @@
-<?php // src/app/Models/ForecastScenarioLine.php
+<?php
+
+// src/app/Models/ForecastScenarioLine.php
 declare(strict_types=1);
+
 namespace App\Models;
+
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -15,5 +19,8 @@ class ForecastScenarioLine extends Model
     #[\Override]
     protected $casts = ['adjustment_pct' => 'decimal:2'];
 
-    public function scenario(): BelongsTo { return $this->belongsTo(ForecastScenario::class, 'forecast_scenario_id'); }
+    public function scenario(): BelongsTo
+    {
+        return $this->belongsTo(ForecastScenario::class, 'forecast_scenario_id');
+    }
 }

--- a/app/Models/Payment.php
+++ b/app/Models/Payment.php
@@ -7,6 +7,7 @@ namespace App\Models;
 use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class Payment extends Model
 {
@@ -36,7 +37,7 @@ class Payment extends Model
         return $this->belongsTo(Invoice::class, 'invoice_id');
     }
 
-    public function journalEntry(): \Illuminate\Database\Eloquent\Relations\BelongsTo
+    public function journalEntry(): BelongsTo
     {
         return $this->belongsTo(JournalEntry::class);
     }

--- a/app/Models/PurchaseRequest.php
+++ b/app/Models/PurchaseRequest.php
@@ -1,5 +1,7 @@
 <?php
+
 declare(strict_types=1);
+
 namespace App\Models;
 
 use App\Concerns\Approvable;
@@ -49,7 +51,18 @@ class PurchaseRequest extends Model
         return (float) $this->total_amount;
     }
 
-    public function supplier(): BelongsTo { return $this->belongsTo(Supplier::class, 'supplier_id', 'supplier_id'); }
-    public function items(): HasMany { return $this->hasMany(PurchaseRequestItem::class); }
-    public function purchaseOrder(): HasOne { return $this->hasOne(PurchaseOrder::class, 'purchase_request_id'); }
+    public function supplier(): BelongsTo
+    {
+        return $this->belongsTo(Supplier::class, 'supplier_id', 'supplier_id');
+    }
+
+    public function items(): HasMany
+    {
+        return $this->hasMany(PurchaseRequestItem::class);
+    }
+
+    public function purchaseOrder(): HasOne
+    {
+        return $this->hasOne(PurchaseOrder::class, 'purchase_request_id');
+    }
 }

--- a/app/Models/SalesOrder.php
+++ b/app/Models/SalesOrder.php
@@ -1,6 +1,10 @@
-<?php // src/app/Models/SalesOrder.php
+<?php
+
+// src/app/Models/SalesOrder.php
 declare(strict_types=1);
+
 namespace App\Models;
+
 use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -41,11 +45,33 @@ class SalesOrder extends Model
         });
     }
 
-    public function customer(): BelongsTo { return $this->belongsTo(Customer::class); }
-    public function estimate(): BelongsTo { return $this->belongsTo(Estimate::class, 'estimate_id', 'estimate_id'); }
-    public function items(): HasMany { return $this->hasMany(SalesOrderItem::class); }
-    public function invoice(): HasOne { return $this->hasOne(Invoice::class, 'sales_order_id'); }
+    public function customer(): BelongsTo
+    {
+        return $this->belongsTo(Customer::class);
+    }
 
-    public function confirm(): void { $this->update(['status' => 'confirmed']); }
-    public function cancel(): void { $this->update(['status' => 'cancelled']); }
+    public function estimate(): BelongsTo
+    {
+        return $this->belongsTo(Estimate::class, 'estimate_id', 'estimate_id');
+    }
+
+    public function items(): HasMany
+    {
+        return $this->hasMany(SalesOrderItem::class);
+    }
+
+    public function invoice(): HasOne
+    {
+        return $this->hasOne(Invoice::class, 'sales_order_id');
+    }
+
+    public function confirm(): void
+    {
+        $this->update(['status' => 'confirmed']);
+    }
+
+    public function cancel(): void
+    {
+        $this->update(['status' => 'cancelled']);
+    }
 }

--- a/app/Models/SalesOrderItem.php
+++ b/app/Models/SalesOrderItem.php
@@ -1,6 +1,10 @@
-<?php // src/app/Models/SalesOrderItem.php
+<?php
+
+// src/app/Models/SalesOrderItem.php
 declare(strict_types=1);
+
 namespace App\Models;
+
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -23,5 +27,8 @@ class SalesOrderItem extends Model
         'tax_amount' => 'decimal:2',
     ];
 
-    public function salesOrder(): BelongsTo { return $this->belongsTo(SalesOrder::class); }
+    public function salesOrder(): BelongsTo
+    {
+        return $this->belongsTo(SalesOrder::class);
+    }
 }

--- a/app/Services/ProcurementService.php
+++ b/app/Services/ProcurementService.php
@@ -1,5 +1,7 @@
 <?php
+
 declare(strict_types=1);
+
 namespace App\Services;
 
 use App\Models\PurchaseOrder;

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -81,7 +81,7 @@ return Application::configure(basePath: dirname(__DIR__))
     ->withSchedule(function (Schedule $schedule): void {
         $schedule->command('recurring:process')->daily()->withoutOverlapping();
         $schedule->command('invoices:send-reminders')->daily();
-        $schedule->job(new EscalateApprovalsJob())->daily();
+        $schedule->job(new EscalateApprovalsJob)->daily();
         $schedule->command('documents:prune')->daily();
         $schedule->command('subscriptions:process')->daily()->withoutOverlapping();
         $schedule->command('revenue:recognize')->daily()->withoutOverlapping();

--- a/config/app.php
+++ b/config/app.php
@@ -7,6 +7,8 @@ use App\Providers\AuthServiceProvider;
 use App\Providers\EventServiceProvider;
 use App\Providers\Filament\AdminPanelProvider;
 use App\Providers\Filament\AppPanelProvider;
+use App\Providers\Filament\CustomerPanelProvider;
+use App\Providers\Filament\VendorPanelProvider;
 use App\Providers\FortifyServiceProvider;
 use App\Providers\JetstreamServiceProvider;
 use App\Providers\RouteServiceProvider;
@@ -180,8 +182,8 @@ return [
         EventServiceProvider::class,
         AdminPanelProvider::class,
         AppPanelProvider::class,
-        App\Providers\Filament\CustomerPanelProvider::class,
-        App\Providers\Filament\VendorPanelProvider::class,
+        CustomerPanelProvider::class,
+        VendorPanelProvider::class,
         RouteServiceProvider::class,
 
         TeamServiceProvider::class,

--- a/config/auth.php
+++ b/config/auth.php
@@ -1,7 +1,9 @@
 <?php
 
 declare(strict_types=1);
+use App\Models\Customer;
 use App\Models\User;
+use App\Models\Vendor;
 
 return [
 
@@ -80,12 +82,12 @@ return [
 
         'customers' => [
             'driver' => 'eloquent',
-            'model' => App\Models\Customer::class,
+            'model' => Customer::class,
         ],
 
         'vendors' => [
             'driver' => 'eloquent',
-            'model' => App\Models\Vendor::class,
+            'model' => Vendor::class,
         ],
     ],
 

--- a/config/documents.php
+++ b/config/documents.php
@@ -1,5 +1,8 @@
-<?php // src/config/documents.php
+<?php
+
+// src/config/documents.php
 declare(strict_types=1);
+
 return [
     'disk' => env('DOCUMENTS_DISK', 'local'),
 ];

--- a/database/migrations/2026_07_05_100001_create_sales_orders_table.php
+++ b/database/migrations/2026_07_05_100001_create_sales_orders_table.php
@@ -1,10 +1,15 @@
-<?php // 2026_07_05_100001_create_sales_orders_table.php
+<?php
+
+// 2026_07_05_100001_create_sales_orders_table.php
 declare(strict_types=1);
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-return new class extends Migration {
-    public function up(): void {
+
+return new class extends Migration
+{
+    public function up(): void
+    {
         Schema::create('sales_orders', function (Blueprint $t): void {
             $t->id();
             $t->foreignId('customer_id')->nullable()->constrained('customers')->nullOnDelete();
@@ -20,5 +25,9 @@ return new class extends Migration {
             $t->timestamps();
         });
     }
-    public function down(): void { Schema::dropIfExists('sales_orders'); }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('sales_orders');
+    }
 };

--- a/database/migrations/2026_07_05_100002_create_sales_order_items_table.php
+++ b/database/migrations/2026_07_05_100002_create_sales_order_items_table.php
@@ -1,10 +1,15 @@
-<?php // 2026_07_05_100002_create_sales_order_items_table.php
+<?php
+
+// 2026_07_05_100002_create_sales_order_items_table.php
 declare(strict_types=1);
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-return new class extends Migration {
-    public function up(): void {
+
+return new class extends Migration
+{
+    public function up(): void
+    {
         Schema::create('sales_order_items', function (Blueprint $t): void {
             $t->id();
             $t->foreignId('sales_order_id')->constrained('sales_orders')->cascadeOnDelete();
@@ -18,5 +23,9 @@ return new class extends Migration {
             $t->timestamps();
         });
     }
-    public function down(): void { Schema::dropIfExists('sales_order_items'); }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('sales_order_items');
+    }
 };

--- a/database/migrations/2026_07_05_100003_add_sales_order_id_to_invoices_table.php
+++ b/database/migrations/2026_07_05_100003_add_sales_order_id_to_invoices_table.php
@@ -1,16 +1,23 @@
-<?php // 2026_07_05_100003_add_sales_order_id_to_invoices_table.php
+<?php
+
+// 2026_07_05_100003_add_sales_order_id_to_invoices_table.php
 declare(strict_types=1);
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-return new class extends Migration {
-    public function up(): void {
+
+return new class extends Migration
+{
+    public function up(): void
+    {
         Schema::table('invoices', function (Blueprint $t): void {
             $t->foreignId('sales_order_id')->nullable()->unique()->after('customer_id')
                 ->constrained('sales_orders')->nullOnDelete();
         });
     }
-    public function down(): void {
+
+    public function down(): void
+    {
         Schema::table('invoices', function (Blueprint $t): void {
             $t->dropConstrainedForeignId('sales_order_id');
         });

--- a/database/migrations/2026_07_06_100001_create_purchase_requests_table.php
+++ b/database/migrations/2026_07_06_100001_create_purchase_requests_table.php
@@ -1,11 +1,14 @@
 <?php
+
 declare(strict_types=1);
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration {
-    public function up(): void {
+return new class extends Migration
+{
+    public function up(): void
+    {
         Schema::create('purchase_requests', function (Blueprint $t): void {
             $t->id();
             $t->foreignId('supplier_id')->nullable()->constrained('suppliers', 'supplier_id')->nullOnDelete();
@@ -22,5 +25,9 @@ return new class extends Migration {
             $t->timestamps();
         });
     }
-    public function down(): void { Schema::dropIfExists('purchase_requests'); }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('purchase_requests');
+    }
 };

--- a/database/migrations/2026_07_06_100002_create_purchase_request_items_table.php
+++ b/database/migrations/2026_07_06_100002_create_purchase_request_items_table.php
@@ -1,11 +1,14 @@
 <?php
+
 declare(strict_types=1);
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration {
-    public function up(): void {
+return new class extends Migration
+{
+    public function up(): void
+    {
         Schema::create('purchase_request_items', function (Blueprint $t): void {
             $t->id();
             $t->foreignId('purchase_request_id')->constrained('purchase_requests')->cascadeOnDelete();
@@ -16,5 +19,9 @@ return new class extends Migration {
             $t->timestamps();
         });
     }
-    public function down(): void { Schema::dropIfExists('purchase_request_items'); }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('purchase_request_items');
+    }
 };

--- a/database/migrations/2026_07_06_100003_add_purchase_request_id_to_purchase_orders_table.php
+++ b/database/migrations/2026_07_06_100003_add_purchase_request_id_to_purchase_orders_table.php
@@ -1,17 +1,22 @@
 <?php
+
 declare(strict_types=1);
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration {
-    public function up(): void {
+return new class extends Migration
+{
+    public function up(): void
+    {
         Schema::table('purchase_orders', function (Blueprint $t): void {
             $t->foreignId('purchase_request_id')->nullable()->unique()->after('purchase_order_id')
                 ->constrained('purchase_requests')->nullOnDelete();
         });
     }
-    public function down(): void {
+
+    public function down(): void
+    {
         Schema::table('purchase_orders', function (Blueprint $t): void {
             $t->dropConstrainedForeignId('purchase_request_id');
         });

--- a/database/migrations/2026_07_07_100001_create_forecast_scenarios_table.php
+++ b/database/migrations/2026_07_07_100001_create_forecast_scenarios_table.php
@@ -1,10 +1,15 @@
-<?php // 2026_07_07_100001_create_forecast_scenarios_table.php
+<?php
+
+// 2026_07_07_100001_create_forecast_scenarios_table.php
 declare(strict_types=1);
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-return new class extends Migration {
-    public function up(): void {
+
+return new class extends Migration
+{
+    public function up(): void
+    {
         Schema::create('forecast_scenarios', function (Blueprint $t): void {
             $t->id();
             $t->string('name');
@@ -12,5 +17,9 @@ return new class extends Migration {
             $t->timestamps();
         });
     }
-    public function down(): void { Schema::dropIfExists('forecast_scenarios'); }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('forecast_scenarios');
+    }
 };

--- a/database/migrations/2026_07_07_100002_create_forecast_scenario_lines_table.php
+++ b/database/migrations/2026_07_07_100002_create_forecast_scenario_lines_table.php
@@ -1,10 +1,15 @@
-<?php // 2026_07_07_100002_create_forecast_scenario_lines_table.php
+<?php
+
+// 2026_07_07_100002_create_forecast_scenario_lines_table.php
 declare(strict_types=1);
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-return new class extends Migration {
-    public function up(): void {
+
+return new class extends Migration
+{
+    public function up(): void
+    {
         Schema::create('forecast_scenario_lines', function (Blueprint $t): void {
             $t->id();
             $t->foreignId('forecast_scenario_id')->constrained()->cascadeOnDelete();
@@ -13,5 +18,9 @@ return new class extends Migration {
             $t->timestamps();
         });
     }
-    public function down(): void { Schema::dropIfExists('forecast_scenario_lines'); }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('forecast_scenario_lines');
+    }
 };

--- a/database/migrations/2026_07_08_100001_create_documents_table.php
+++ b/database/migrations/2026_07_08_100001_create_documents_table.php
@@ -1,11 +1,14 @@
 <?php
+
 declare(strict_types=1);
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration {
-    public function up(): void {
+return new class extends Migration
+{
+    public function up(): void
+    {
         Schema::create('documents', function (Blueprint $t): void {
             $t->id();
             $t->string('documentable_type');
@@ -18,5 +21,9 @@ return new class extends Migration {
             $t->index(['documentable_type', 'documentable_id']);
         });
     }
-    public function down(): void { Schema::dropIfExists('documents'); }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('documents');
+    }
 };

--- a/database/migrations/2026_07_09_100001_create_plans_table.php
+++ b/database/migrations/2026_07_09_100001_create_plans_table.php
@@ -1,10 +1,15 @@
-<?php // 2026_07_09_100001_create_plans_table.php
+<?php
+
+// 2026_07_09_100001_create_plans_table.php
 declare(strict_types=1);
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-return new class extends Migration {
-    public function up(): void {
+
+return new class extends Migration
+{
+    public function up(): void
+    {
         Schema::create('plans', function (Blueprint $t): void {
             $t->id();
             $t->string('name');
@@ -15,5 +20,9 @@ return new class extends Migration {
             $t->timestamps();
         });
     }
-    public function down(): void { Schema::dropIfExists('plans'); }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('plans');
+    }
 };

--- a/database/migrations/2026_07_09_100002_create_subscriptions_table.php
+++ b/database/migrations/2026_07_09_100002_create_subscriptions_table.php
@@ -1,10 +1,15 @@
-<?php // 2026_07_09_100002_create_subscriptions_table.php
+<?php
+
+// 2026_07_09_100002_create_subscriptions_table.php
 declare(strict_types=1);
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-return new class extends Migration {
-    public function up(): void {
+
+return new class extends Migration
+{
+    public function up(): void
+    {
         Schema::create('subscriptions', function (Blueprint $t): void {
             $t->id();
             $t->foreignId('customer_id')->constrained('customers')->cascadeOnDelete();
@@ -18,5 +23,9 @@ return new class extends Migration {
             $t->timestamps();
         });
     }
-    public function down(): void { Schema::dropIfExists('subscriptions'); }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('subscriptions');
+    }
 };

--- a/database/migrations/2026_07_10_100001_create_revenue_schedules_table.php
+++ b/database/migrations/2026_07_10_100001_create_revenue_schedules_table.php
@@ -1,10 +1,14 @@
 <?php
+
 declare(strict_types=1);
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-return new class extends Migration {
-    public function up(): void {
+
+return new class extends Migration
+{
+    public function up(): void
+    {
         Schema::create('revenue_schedules', function (Blueprint $t): void {
             $t->id();
             $t->foreignId('invoice_id')->unique()->constrained()->cascadeOnDelete();
@@ -18,5 +22,9 @@ return new class extends Migration {
             $t->timestamps();
         });
     }
-    public function down(): void { Schema::dropIfExists('revenue_schedules'); }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('revenue_schedules');
+    }
 };

--- a/database/migrations/2026_07_10_100002_create_revenue_schedule_entries_table.php
+++ b/database/migrations/2026_07_10_100002_create_revenue_schedule_entries_table.php
@@ -1,10 +1,14 @@
 <?php
+
 declare(strict_types=1);
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-return new class extends Migration {
-    public function up(): void {
+
+return new class extends Migration
+{
+    public function up(): void
+    {
         Schema::create('revenue_schedule_entries', function (Blueprint $t): void {
             $t->id();
             $t->foreignId('revenue_schedule_id')->constrained()->cascadeOnDelete();
@@ -18,5 +22,9 @@ return new class extends Migration {
             $t->unique(['revenue_schedule_id', 'period_number'], 'rev_sched_entry_period_unique');
         });
     }
-    public function down(): void { Schema::dropIfExists('revenue_schedule_entries'); }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('revenue_schedule_entries');
+    }
 };

--- a/database/migrations/2026_07_12_100001_add_journal_entry_id_to_payments_table.php
+++ b/database/migrations/2026_07_12_100001_add_journal_entry_id_to_payments_table.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;

--- a/database/migrations/2026_12_04_000001_create_approval_rules_table.php
+++ b/database/migrations/2026_12_04_000001_create_approval_rules_table.php
@@ -1,10 +1,12 @@
 <?php
+
 declare(strict_types=1);
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration {
+return new class extends Migration
+{
     public function up(): void
     {
         Schema::create('approval_rules', function (Blueprint $table): void {
@@ -20,5 +22,9 @@ return new class extends Migration {
             $table->index(['team_id', 'approvable_type', 'is_active']);
         });
     }
-    public function down(): void { Schema::dropIfExists('approval_rules'); }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('approval_rules');
+    }
 };

--- a/database/migrations/2026_12_04_000002_create_approval_requests_table.php
+++ b/database/migrations/2026_12_04_000002_create_approval_requests_table.php
@@ -1,10 +1,12 @@
 <?php
+
 declare(strict_types=1);
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration {
+return new class extends Migration
+{
     public function up(): void
     {
         Schema::create('approval_requests', function (Blueprint $table): void {
@@ -19,5 +21,9 @@ return new class extends Migration {
             $table->index(['approvable_type', 'approvable_id']);
         });
     }
-    public function down(): void { Schema::dropIfExists('approval_requests'); }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('approval_requests');
+    }
 };

--- a/database/migrations/2026_12_04_000003_create_approval_steps_table.php
+++ b/database/migrations/2026_12_04_000003_create_approval_steps_table.php
@@ -1,10 +1,12 @@
 <?php
+
 declare(strict_types=1);
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration {
+return new class extends Migration
+{
     public function up(): void
     {
         Schema::create('approval_steps', function (Blueprint $table): void {
@@ -22,5 +24,9 @@ return new class extends Migration {
             $table->index(['status', 'deadline_at']);
         });
     }
-    public function down(): void { Schema::dropIfExists('approval_steps'); }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('approval_steps');
+    }
 };

--- a/tests/Feature/Api/JournalEntryApiTest.php
+++ b/tests/Feature/Api/JournalEntryApiTest.php
@@ -7,6 +7,7 @@ namespace Tests\Feature\Api;
 use App\Models\Account;
 use App\Models\JournalEntry;
 use App\Models\User;
+use App\Services\TeamManagementService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -22,7 +23,7 @@ class JournalEntryApiTest extends TestCase
     {
         parent::setUp();
         $this->user = User::factory()->create();
-        $this->teamId = app(\App\Services\TeamManagementService::class)
+        $this->teamId = app(TeamManagementService::class)
             ->createPersonalTeamForUser($this->user)->id;
         $this->user = $this->user->fresh();
     }

--- a/tests/Feature/Approval/ApprovalNotificationTest.php
+++ b/tests/Feature/Approval/ApprovalNotificationTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Feature\Approval;
 
 use App\Models\ApprovalRequest;
+use App\Models\ApprovalRule;
 use App\Models\ApprovalStep;
 use App\Models\User;
 use App\Notifications\ApprovalRequestedNotification;
@@ -37,7 +38,7 @@ class ApprovalNotificationTest extends TestCase
             'team_id' => $teamId,
             'approvable_type' => 'Bill',
             'approvable_id' => 1,
-            'rule_id' => \App\Models\ApprovalRule::create([
+            'rule_id' => ApprovalRule::create([
                 'team_id' => $teamId,
                 'approvable_type' => 'Bill',
                 'min_amount' => 0,

--- a/tests/Feature/Approval/ApprovalServiceTest.php
+++ b/tests/Feature/Approval/ApprovalServiceTest.php
@@ -50,7 +50,7 @@ class ApprovalServiceTest extends TestCase
         $bill->submitForApproval();
         $step = $bill->approvalRequest()->first()->steps()->first();
 
-        $this->expectException(\App\Exceptions\ApprovalDeniedException::class);
+        $this->expectException(ApprovalDeniedException::class);
         app(ApprovalService::class)->approve($step, $intruder);
     }
 

--- a/tests/Feature/Approval/EscalateApprovalsJobTest.php
+++ b/tests/Feature/Approval/EscalateApprovalsJobTest.php
@@ -56,7 +56,7 @@ class EscalateApprovalsJobTest extends TestCase
         // Force the deadline into the past so the job picks it up.
         $step->forceFill(['deadline_at' => now()->subDay()])->save();
 
-        (new EscalateApprovalsJob())->handle();
+        (new EscalateApprovalsJob)->handle();
 
         $step->refresh();
         $this->assertSame(ApprovalStep::STATUS_ESCALATED, $step->status);
@@ -93,7 +93,7 @@ class EscalateApprovalsJobTest extends TestCase
         $step = $bill->approvalRequest()->first()->steps()->first();
         $this->assertNull($step->deadline_at, 'no deadline_days on the rule means no deadline');
 
-        (new EscalateApprovalsJob())->handle();
+        (new EscalateApprovalsJob)->handle();
 
         $this->assertSame(ApprovalStep::STATUS_PENDING, $step->fresh()->status);
     }

--- a/tests/Feature/Approval/PendingApprovalsPageTest.php
+++ b/tests/Feature/Approval/PendingApprovalsPageTest.php
@@ -29,7 +29,7 @@ class PendingApprovalsPageTest extends TestCase
         $step = $bill->approvalRequest()->first()->steps()->first();
 
         $this->actingAs($manager);
-        $page = new PendingApprovals();
+        $page = new PendingApprovals;
 
         $this->assertTrue($page->actionableStepsQuery()->pluck('id')->contains($step->id));
 
@@ -49,7 +49,7 @@ class PendingApprovalsPageTest extends TestCase
         $bill->submitForApproval();
 
         $this->actingAs($intruder);
-        $page = new PendingApprovals();
+        $page = new PendingApprovals;
 
         $this->assertTrue($page->actionableStepsQuery()->get()->isEmpty());
     }

--- a/tests/Feature/EnsureTwoFactorEnabledTest.php
+++ b/tests/Feature/EnsureTwoFactorEnabledTest.php
@@ -102,7 +102,7 @@ class EnsureTwoFactorEnabledTest extends TestCase
         $request = Request::create('/app', 'GET');
         $request->setRouteResolver(fn (): Route => (new Route('GET', '/app', []))->name($routeName));
 
-        return (new EnsureTwoFactorEnabled())->handle(
+        return (new EnsureTwoFactorEnabled)->handle(
             $request,
             fn (): Response => new Response('ok'),
         );

--- a/tests/Feature/Forecast/ForecastScenarioModelTest.php
+++ b/tests/Feature/Forecast/ForecastScenarioModelTest.php
@@ -1,5 +1,8 @@
-<?php // src/tests/Feature/Forecast/ForecastScenarioModelTest.php
+<?php
+
+// src/tests/Feature/Forecast/ForecastScenarioModelTest.php
 declare(strict_types=1);
+
 namespace Tests\Feature\Forecast;
 
 use App\Models\ForecastScenario;

--- a/tests/Feature/Forecast/ForecastServiceTest.php
+++ b/tests/Feature/Forecast/ForecastServiceTest.php
@@ -1,5 +1,8 @@
-<?php // src/tests/Feature/Forecast/ForecastServiceTest.php
+<?php
+
+// src/tests/Feature/Forecast/ForecastServiceTest.php
 declare(strict_types=1);
+
 namespace Tests\Feature\Forecast;
 
 use App\Models\Account;
@@ -24,7 +27,7 @@ class ForecastServiceTest extends TestCase
         $revenue = Account::factory()->create(['team_id' => $teamId, 'account_type' => 'revenue']);
         $expense = Account::factory()->create(['team_id' => $teamId, 'account_type' => 'expense']);
         foreach ([100, 200, 300] as $i => $amt) {
-            Transaction::create(['account_id' => $revenue->id, 'transaction_date' => "2026-0".($i + 1)."-01", 'amount' => $amt]);
+            Transaction::create(['account_id' => $revenue->id, 'transaction_date' => '2026-0'.($i + 1).'-01', 'amount' => $amt]);
         }
         Transaction::create(['account_id' => $expense->id, 'transaction_date' => '2026-01-01', 'amount' => 50]);
     }

--- a/tests/Feature/HmrcRtiPayeTest.php
+++ b/tests/Feature/HmrcRtiPayeTest.php
@@ -8,6 +8,7 @@ use App\Models\Company;
 use App\Models\HmrcPayeSubmission;
 use App\Services\HmrcAuthService;
 use App\Services\HmrcRtiPayeService;
+use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
 use Tests\TestCase;
@@ -107,7 +108,7 @@ class HmrcRtiPayeTest extends TestCase
     }
 
     /** A well-formed HMRC RTI XML envelope carrying a correlation id. */
-    private function fakeRtiResponse(): \GuzzleHttp\Promise\PromiseInterface
+    private function fakeRtiResponse(): PromiseInterface
     {
         return Http::response(
             '<?xml version="1.0" encoding="UTF-8"?>'

--- a/tests/Feature/PaymentPosting/PaymentModelTest.php
+++ b/tests/Feature/PaymentPosting/PaymentModelTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Feature\PaymentPosting;

--- a/tests/Feature/PaymentPosting/PostPaymentCommandTest.php
+++ b/tests/Feature/PaymentPosting/PostPaymentCommandTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Feature\PaymentPosting;

--- a/tests/Feature/Procurement/PurchaseRequestApprovalTest.php
+++ b/tests/Feature/Procurement/PurchaseRequestApprovalTest.php
@@ -1,5 +1,8 @@
-<?php // src/tests/Feature/Procurement/PurchaseRequestApprovalTest.php
+<?php
+
+// src/tests/Feature/Procurement/PurchaseRequestApprovalTest.php
 declare(strict_types=1);
+
 namespace Tests\Feature\Procurement;
 
 use App\Models\ApprovalRule;

--- a/tests/Feature/Procurement/PurchaseRequestModelTest.php
+++ b/tests/Feature/Procurement/PurchaseRequestModelTest.php
@@ -1,5 +1,7 @@
 <?php
+
 declare(strict_types=1);
+
 namespace Tests\Feature\Procurement;
 
 use App\Models\PurchaseRequest;

--- a/tests/Feature/Procurement/PurchaseRequestTenancyTest.php
+++ b/tests/Feature/Procurement/PurchaseRequestTenancyTest.php
@@ -1,5 +1,8 @@
-<?php // src/tests/Feature/Procurement/PurchaseRequestTenancyTest.php
+<?php
+
+// src/tests/Feature/Procurement/PurchaseRequestTenancyTest.php
 declare(strict_types=1);
+
 namespace Tests\Feature\Procurement;
 
 use App\Models\PurchaseRequest;

--- a/tests/Feature/TwoFactorEnrollmentTest.php
+++ b/tests/Feature/TwoFactorEnrollmentTest.php
@@ -38,7 +38,7 @@ class TwoFactorEnrollmentTest extends TestCase
 
         // A valid TOTP from the authenticator app completes enrolment.
         $secret = decrypt($user->two_factor_secret);
-        $code = (new Google2FA())->getCurrentOtp(is_string($secret) ? $secret : '');
+        $code = (new Google2FA)->getCurrentOtp(is_string($secret) ? $secret : '');
 
         $page->set('twoFactorCode', $code)->call('confirmTwoFactor');
 

--- a/tests/Unit/DoubleEntryValidatorTest.php
+++ b/tests/Unit/DoubleEntryValidatorTest.php
@@ -81,7 +81,7 @@ class DoubleEntryValidatorTest extends TestCase
         // lines === null -> legacy branch reads request() input
         request()->merge(['debit_amount' => 250.00, 'credit_amount' => 250.00]);
 
-        $validator = new DoubleEntryValidator();
+        $validator = new DoubleEntryValidator;
 
         $this->assertTrue($validator->passes('debit_amount', 250.00));
     }
@@ -90,7 +90,7 @@ class DoubleEntryValidatorTest extends TestCase
     {
         request()->merge(['debit_amount' => 250.00, 'credit_amount' => 100.00]);
 
-        $validator = new DoubleEntryValidator();
+        $validator = new DoubleEntryValidator;
 
         $this->assertFalse($validator->passes('debit_amount', 250.00));
     }

--- a/tests/Unit/Models/ApprovalModelsTest.php
+++ b/tests/Unit/Models/ApprovalModelsTest.php
@@ -1,5 +1,7 @@
 <?php
+
 declare(strict_types=1);
+
 namespace Tests\Unit\Models;
 
 use App\Models\ApprovalRule;


### PR DESCRIPTION
## Why

Two pre-GA de-riskers flagged during release readiness. Building the smoke test surfaced that **the production Octane image did not build or boot** — the SQLite unit suite never exercises it.

## Prod image fixes (`fix(docker)`)

1. **Build failure.** `bootstrap/cache/{packages,services}.php` were committed, pinning the dev-only `PailServiceProvider`. `COPY . .` baked them into the `--no-dev` image; `package:discover` then fataled with *Class "Laravel\Pail\PailServiceProvider" not found*. Untracked (already covered by `.gitignore`) + added `.dockerignore` so the clean prod `vendor/` and generated caches never leak into the build context.
2. **Boot fatal.** `opcache.file_cache = 60` — the directive is a **directory path**, not a number, so PHP fataled at the first `artisan` call (*opcache.file_cache must be a full path of an accessible directory*). Removed; in-memory opcache is primary.

Verified locally: image builds, boots, `GET /up` → **200**.

## CI jobs (`ci`)

- **`tests-mysql`** — runs the suite against MySQL 8.4. SQLite `:memory:` masks prod-only failures MySQL enforces (unknown-column string fallback, VARCHAR overflow — both have shipped bugs here). Real env vars override `phpunit.xml`'s `<env>`, reusing one suite on both drivers. Verified: **603 passed** on MySQL 8.4.
- **`prod-boot` smoke** — builds the shipping Octane image, boots it, asserts `GET /up` = 200. Regression guard for the two fixes above.

## Notes

- RoadRunner binary auto-downloads at container start (Octane default); fine for networked CI/prod. Baking it at build time is an optional follow-up for air-gapped deploys.