### PR TITLE
security: mandatory 2FA, Plaid webhook JWT, payment maker-checker (follow-up to #859)

### DIFF
--- a/app/Http/Controllers/Api/RevolutController.php
+++ b/app/Http/Controllers/Api/RevolutController.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\Controller;
 use App\Models\BankAccountBalance;
 use App\Models\BankConnection;
 use App\Models\BankFeedTransaction;
+use App\Models\OutboundPayment;
 use App\Models\Transaction;
 use App\Services\RevolutService;
 use Exception;
@@ -377,16 +378,53 @@ class RevolutController extends Controller
                 ], 409);
             }
 
-            $paymentData = $request->only(['account_id', 'receiver', 'amount', 'currency', 'reference']);
-            $paymentData['request_id'] = $request->input('idempotency_key');
+            // Route through the maker-checker approval flow. Below the ApprovalRule
+            // threshold it auto-approves and the SendApprovedOutboundPayment listener
+            // fires the send inline; above threshold it waits for a second approver
+            // (surfaced in the PendingApprovals page). The actual Revolut call — with
+            // idempotency_key as request_id — happens in that listener.
+            $payment = OutboundPayment::create([
+                'team_id' => $connection->team_id,
+                'bank_connection_id' => $connection->id,
+                'requested_by' => $request->user()->id,
+                'account_id' => $request->input('account_id'),
+                'receiver' => $request->input('receiver'),
+                'amount' => $request->input('amount'),
+                'currency' => $request->input('currency'),
+                'reference' => $request->input('reference'),
+                'idempotency_key' => $request->input('idempotency_key'),
+                'status' => OutboundPayment::STATUS_PENDING_APPROVAL,
+                'approval_status' => 'draft',
+            ]);
 
-            $result = $this->revolutService->sendPayment($connection, $paymentData);
+            $payment->submitForApproval();
+            $payment->refresh();
 
+            if ($payment->status === OutboundPayment::STATUS_SENT) {
+                return response()->json([
+                    'success' => true,
+                    'message' => 'Payment sent successfully',
+                    'payment' => $payment->result,
+                ], 201);
+            }
+
+            if ($payment->status === OutboundPayment::STATUS_FAILED) {
+                Cache::forget($guardKey); // allow a corrected retry
+                Log::error('Revolut payment failed to send', ['payment_id' => $payment->id]);
+
+                return response()->json([
+                    'success' => false,
+                    'message' => 'Payment failed to send',
+                ], 500);
+            }
+
+            // Above threshold: awaiting a second approver before it sends.
             return response()->json([
                 'success' => true,
-                'message' => 'Payment sent successfully',
-                'payment' => $result,
-            ], 201);
+                'message' => 'Payment queued for approval',
+                'payment_id' => $payment->id,
+                'status' => $payment->status,
+            ], 202);
         } catch (Exception $e) {
             if (isset($guardKey)) {
                 Cache::forget($guardKey);

--- a/app/Http/Middleware/EnsureTwoFactorEnabled.php
+++ b/app/Http/Middleware/EnsureTwoFactorEnabled.php
@@ -57,10 +57,11 @@ class EnsureTwoFactorEnabled
      */
     protected function shouldEnforce(User $user): bool
     {
-        // ponytail: OFF by default — the EditProfile page has no 2FA enrolment form
-        // yet, so enforcing without it would redirect-loop admins into a lockout.
-        // Ships dormant; flip config('accounting.enforce_2fa') once enrolment UI lands.
-        if (! config('accounting.enforce_2fa', false)) {
+        // ON by default (config/accounting.php). The EditProfile page has the 2FA
+        // enrolment form and onAllowedRoute() keeps it reachable, so an un-enrolled
+        // admin is redirected to enrol, not locked out. Deploys opt out with
+        // ACCOUNTING_ENFORCE_2FA=false.
+        if (! config('accounting.enforce_2fa', true)) {
             return false;
         }
 

--- a/app/Listeners/SendApprovedOutboundPayment.php
+++ b/app/Listeners/SendApprovedOutboundPayment.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Listeners;
+
+use App\Events\ApprovableApproved;
+use App\Models\BankConnection;
+use App\Models\OutboundPayment;
+use App\Services\RevolutService;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * Executes an outbound payment once its approval clears. Fires for BOTH paths:
+ * the auto-approve (below-threshold) case synchronously inside submitForApproval,
+ * and the deferred case when the final approver approves. Synchronous (not
+ * queued) so the controller can read the outcome in the same request.
+ */
+class SendApprovedOutboundPayment
+{
+    public function __construct(private readonly RevolutService $revolut) {}
+
+    public function handle(ApprovableApproved $event): void
+    {
+        $payment = $event->approvable;
+
+        // Only outbound payments; and never re-send one already sent.
+        if (! $payment instanceof OutboundPayment || $payment->status === OutboundPayment::STATUS_SENT) {
+            return;
+        }
+
+        $connection = $payment->bankConnection;
+
+        if (! $connection instanceof BankConnection) {
+            $payment->update(['status' => OutboundPayment::STATUS_FAILED]);
+
+            return;
+        }
+
+        try {
+            // idempotency_key -> Revolut request_id: a retry returns the same
+            // payment rather than double-spending.
+            $result = $this->revolut->sendPayment($connection, [
+                'account_id' => $payment->account_id,
+                'receiver' => $payment->receiver,
+                'amount' => (float) $payment->amount,
+                'currency' => $payment->currency,
+                'reference' => $payment->reference,
+                'request_id' => $payment->idempotency_key,
+            ]);
+
+            $payment->update([
+                'status' => OutboundPayment::STATUS_SENT,
+                'result' => $result,
+                'request_id' => $payment->idempotency_key,
+                'sent_at' => now(),
+            ]);
+        } catch (Throwable $e) {
+            $payment->update(['status' => OutboundPayment::STATUS_FAILED]);
+            Log::error('Outbound payment send failed', [
+                'payment_id' => $payment->id,
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+}

--- a/app/Models/OutboundPayment.php
+++ b/app/Models/OutboundPayment.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Concerns\Approvable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * A bank payment instruction pending execution. Routed through the Approvable
+ * maker-checker flow: below the ApprovalRule threshold it auto-approves and the
+ * SendApprovedOutboundPayment listener fires it immediately; above threshold it
+ * waits for a second approver before the same listener sends it.
+ */
+class OutboundPayment extends Model
+{
+    use Approvable;
+
+    public const STATUS_PENDING_APPROVAL = 'pending_approval';
+
+    public const STATUS_SENT = 'sent';
+
+    public const STATUS_FAILED = 'failed';
+
+    protected $fillable = [
+        'team_id',
+        'bank_connection_id',
+        'requested_by',
+        'account_id',
+        'receiver',
+        'amount',
+        'currency',
+        'reference',
+        'idempotency_key',
+        'status',
+        'request_id',
+        'result',
+        'sent_at',
+        'approval_status',
+        'approved_by',
+        'approved_at',
+        'rejection_reason',
+    ];
+
+    protected $casts = [
+        'receiver' => 'array',
+        'result' => 'array',
+        'amount' => 'decimal:2',
+        'sent_at' => 'datetime',
+        'approved_at' => 'datetime',
+    ];
+
+    public function approvalAmount(): float
+    {
+        return (float) $this->amount;
+    }
+
+    public function bankConnection(): BelongsTo
+    {
+        return $this->belongsTo(BankConnection::class);
+    }
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Providers;
 
+use App\Events\ApprovableApproved;
+use App\Listeners\SendApprovedOutboundPayment;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
@@ -19,6 +21,12 @@ class EventServiceProvider extends ServiceProvider
     protected $listen = [
         Registered::class => [
             SendEmailVerificationNotification::class,
+        ],
+        // Execute an outbound payment once its approval clears (auto-approve
+        // below threshold, or the final approver above it). No-op for other
+        // approvables.
+        ApprovableApproved::class => [
+            SendApprovedOutboundPayment::class,
         ],
     ];
 

--- a/app/Services/ApprovalService.php
+++ b/app/Services/ApprovalService.php
@@ -35,6 +35,16 @@ class ApprovalService
             return false;
         }
 
+        // Maker != checker: whoever requested an approvable may not approve it.
+        // Only approvables that record a requester (e.g. OutboundPayment) carry
+        // requested_by; isset() is false (never throws) for those that don't.
+        $approvable = $request->approvable;
+
+        if ($approvable !== null && isset($approvable->requested_by)
+            && (int) $approvable->requested_by === (int) $user->getKey()) {
+            return false;
+        }
+
         if (! in_array($step->status, [ApprovalStep::STATUS_PENDING, ApprovalStep::STATUS_ESCALATED], true)) {
             return false;
         }

--- a/app/Services/PlaidService.php
+++ b/app/Services/PlaidService.php
@@ -6,8 +6,11 @@ namespace App\Services;
 
 use App\Models\BankConnection;
 use Exception;
+use Firebase\JWT\JWK;
+use Firebase\JWT\JWT;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 
@@ -327,34 +330,115 @@ class PlaidService
      */
     public function verifyWebhookSignature(string $bodyJson, array $headers): bool
     {
-        $verificationKey = config('services.plaid.webhook_verification_key');
+        // Plaid signs webhooks with a per-message JWS (ES256) in the
+        // Plaid-Verification header, NOT a shared HMAC secret. The JWT is signed
+        // with a rotating key fetched from /webhook_verification_key/get by kid,
+        // and its request_body_sha256 claim binds it to this exact body.
+        $jwt = $this->extractVerificationHeader($headers);
 
-        // If no verification key is configured, log warning and reject
-        if (empty($verificationKey)) {
-            Log::warning('Plaid webhook verification key not configured - rejecting webhook');
-
-            return false;
-        }
-
-        // Get signature from headers (Plaid sends it as 'Plaid-Verification' header)
-        $signature = $headers['plaid-verification'] ?? $headers['Plaid-Verification'] ?? null;
-
-        // Headers from $request->headers->all() return arrays; extract the first value
-        if (is_array($signature)) {
-            $signature = $signature[0] ?? null;
-        }
-
-        if (empty($signature)) {
-            Log::warning('Plaid webhook signature missing from headers');
+        if ($jwt === null) {
+            Log::warning('Plaid webhook: missing Plaid-Verification header');
 
             return false;
         }
 
-        // Compute HMAC-SHA256 signature
-        $computedSignature = hash_hmac('sha256', $bodyJson, (string) $verificationKey, true);
-        $computedSignatureBase64 = base64_encode($computedSignature);
+        try {
+            $segments = explode('.', $jwt);
 
-        // Use hash_equals for timing-safe comparison
-        return hash_equals($computedSignatureBase64, $signature);
+            if (count($segments) !== 3) {
+                return false;
+            }
+
+            $header = json_decode($this->base64UrlDecode($segments[0]), true);
+
+            // Only ES256 is ever accepted — never 'none'/HS* (algorithm-confusion).
+            if (! is_array($header) || ($header['alg'] ?? null) !== 'ES256' || empty($header['kid'])) {
+                Log::warning('Plaid webhook: unexpected JWT header (alg/kid)');
+
+                return false;
+            }
+
+            $jwk = $this->plaidVerificationKey((string) $header['kid']);
+
+            if ($jwk === null) {
+                return false;
+            }
+
+            // Verifies the ES256 signature against Plaid's public key. Throws on
+            // any tamper/mismatch → caught below and rejected.
+            JWT::$leeway = 60; // tolerate minor clock skew on iat
+            $claims = JWT::decode($jwt, JWK::parseKey($jwk, 'ES256'));
+
+            // Replay guard: Plaid JWTs carry iat; reject anything older than 5 min.
+            $iat = (int) ($claims->iat ?? 0);
+
+            if ($iat <= 0 || (now()->timestamp - $iat) > 300) {
+                Log::warning('Plaid webhook: stale or missing iat');
+
+                return false;
+            }
+
+            // Bind the token to THIS body: the JWT claims the sha256 of the raw body.
+            $expected = $claims->request_body_sha256 ?? null;
+
+            return is_string($expected) && hash_equals($expected, hash('sha256', $bodyJson));
+        } catch (\Throwable $e) {
+            Log::warning('Plaid webhook signature verification failed', ['error' => $e->getMessage()]);
+
+            return false;
+        }
+    }
+
+    private function extractVerificationHeader(array $headers): ?string
+    {
+        $value = $headers['plaid-verification'] ?? $headers['Plaid-Verification'] ?? null;
+
+        // $request->headers->all() returns each header as an array of values.
+        if (is_array($value)) {
+            $value = $value[0] ?? null;
+        }
+
+        return is_string($value) && $value !== '' ? $value : null;
+    }
+
+    /**
+     * Fetch (and cache by kid) the JWK Plaid signs webhooks with. Only a
+     * successful fetch is cached, so a transient outage doesn't poison it.
+     * ponytail: 24h TTL per kid; a rotated key arrives under a new kid and
+     * fetches fresh on its first webhook.
+     *
+     * @return array<string, mixed>|null
+     */
+    private function plaidVerificationKey(string $kid): ?array
+    {
+        $cacheKey = "plaid_jwk:{$kid}";
+        $cached = Cache::get($cacheKey);
+
+        if (is_array($cached)) {
+            return $cached;
+        }
+
+        $response = Http::timeout(10)->post("{$this->baseUrl}/webhook_verification_key/get", [
+            'client_id' => $this->clientId,
+            'secret' => $this->secret,
+            'key_id' => $kid,
+        ]);
+
+        $jwk = $response->successful() ? $response->json('key') : null;
+
+        if (! is_array($jwk)) {
+            Log::warning('Plaid webhook: could not fetch verification key', ['kid' => $kid]);
+
+            return null;
+        }
+
+        Cache::put($cacheKey, $jwk, now()->addHours(24));
+
+        return $jwk;
+    }
+
+    private function base64UrlDecode(string $data): string
+    {
+        return (string) base64_decode(strtr($data, '-_', '+/'), true);
     }
 }

--- a/config/accounting.php
+++ b/config/accounting.php
@@ -21,5 +21,9 @@ return [
     | page isn't wired yet, so enabling this without it would lock admins out.
     | Flip to true once the enrolment form ships.
     */
-    'enforce_2fa' => env('ACCOUNTING_ENFORCE_2FA', false),
+    // Mandatory 2FA for privileged (super_admin/admin) users by default. The
+    // EnsureTwoFactorEnabled middleware gracefully redirects an un-enrolled user
+    // to the enrolment UI rather than locking them out. Override per deploy with
+    // ACCOUNTING_ENFORCE_2FA=false.
+    'enforce_2fa' => env('ACCOUNTING_ENFORCE_2FA', true),
 ];

--- a/database/migrations/2026_12_05_000001_create_outbound_payments_table.php
+++ b/database/migrations/2026_12_05_000001_create_outbound_payments_table.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('outbound_payments', function (Blueprint $table): void {
+            $table->id();
+            $table->unsignedBigInteger('team_id')->index();
+            $table->unsignedBigInteger('bank_connection_id')->index();
+            $table->unsignedBigInteger('requested_by')->index(); // maker (for maker != checker)
+
+            // Payment instruction (mirrors the Revolut /pay body).
+            $table->string('account_id');
+            $table->json('receiver');
+            $table->decimal('amount', 15, 2);
+            $table->string('currency', 3);
+            $table->string('reference');
+            $table->string('idempotency_key'); // reused as Revolut request_id
+
+            // Execution state: pending_approval -> sent | failed.
+            $table->string('status')->default('pending_approval')->index();
+            $table->string('request_id')->nullable();
+            $table->json('result')->nullable();
+            $table->timestamp('sent_at')->nullable();
+
+            // Approval state (Approvable trait): draft -> pending -> approved | rejected.
+            $table->string('approval_status')->default('draft');
+            $table->unsignedBigInteger('approved_by')->nullable();
+            $table->timestamp('approved_at')->nullable();
+            $table->text('rejection_reason')->nullable();
+
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('outbound_payments');
+    }
+};

--- a/tests/Feature/Api/OutboundPaymentApprovalTest.php
+++ b/tests/Feature/Api/OutboundPaymentApprovalTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Exceptions\ApprovalDeniedException;
+use App\Models\ApprovalRule;
+use App\Models\BankConnection;
+use App\Models\OutboundPayment;
+use App\Models\User;
+use App\Services\ApprovalService;
+use App\Services\TeamManagementService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Notification;
+use Laravel\Sanctum\Sanctum;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class OutboundPaymentApprovalTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private int $team;
+
+    private User $maker;
+
+    private BankConnection $connection;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Notification::fake();
+
+        config()->set('services.revolut', [
+            'client_id' => 'test_client',
+            'client_secret' => 'test_secret',
+            'environment' => 'sandbox',
+            'redirect_uri' => 'https://app.test/api/revolut/callback',
+        ]);
+
+        $this->maker = User::factory()->create();
+        app(TeamManagementService::class)->createPersonalTeamForUser($this->maker);
+        $this->maker = $this->maker->fresh();
+        $this->team = (int) $this->maker->current_team_id;
+        Role::findOrCreate('approver', 'web');
+        $this->maker->assignRole('approver');
+
+        $this->connection = BankConnection::create([
+            'user_id' => $this->maker->id,
+            'team_id' => $this->team,
+            'bank_id' => 'revolut',
+            'institution_name' => 'Revolut Business',
+            'revolut_access_token' => 'access-token',
+            'revolut_token_expires_at' => now()->addHour(),
+            'status' => 'active',
+        ]);
+    }
+
+    private function payload(float $amount): array
+    {
+        return [
+            'idempotency_key' => 'key-'.$amount,
+            'account_id' => 'acc-1',
+            'receiver' => ['counterparty_id' => 'cp-1'],
+            'amount' => $amount,
+            'currency' => 'GBP',
+            'reference' => 'Invoice 42',
+        ];
+    }
+
+    private function rule(float $threshold): void
+    {
+        ApprovalRule::create([
+            'team_id' => $this->team,
+            'approvable_type' => 'OutboundPayment',
+            'min_amount' => $threshold,
+            'steps' => ['approver'],
+            'is_active' => true,
+        ]);
+    }
+
+    public function test_payment_below_threshold_sends_immediately(): void
+    {
+        Http::fake(['sandbox-b2b.revolut.com/api/1.0/pay' => Http::response(['id' => 'pay-1'], 200)]);
+        $this->rule(1000); // threshold 1000; a 500 payment is below it -> auto-approve
+
+        Sanctum::actingAs($this->maker, ['payments:write']);
+        $response = $this->postJson("/api/revolut/connections/{$this->connection->id}/pay", $this->payload(500));
+
+        $response->assertCreated();
+        Http::assertSent(fn ($r) => str_contains($r->url(), '/pay'));
+        $this->assertSame('sent', OutboundPayment::first()->status);
+    }
+
+    public function test_payment_above_threshold_requires_approval(): void
+    {
+        Http::fake();
+        $this->rule(1000);
+
+        Sanctum::actingAs($this->maker, ['payments:write']);
+        $response = $this->postJson("/api/revolut/connections/{$this->connection->id}/pay", $this->payload(5000));
+
+        $response->assertStatus(202)->assertJsonPath('status', 'pending_approval');
+        Http::assertNothingSent(); // no money moves until approved
+        $this->assertDatabaseHas('outbound_payments', [
+            'team_id' => $this->team,
+            'status' => 'pending_approval',
+            'approval_status' => 'pending',
+        ]);
+    }
+
+    public function test_approval_by_a_second_user_executes_the_payment(): void
+    {
+        Http::fake(['sandbox-b2b.revolut.com/api/1.0/pay' => Http::response(['id' => 'pay-9'], 200)]);
+        $this->rule(1000);
+
+        Sanctum::actingAs($this->maker, ['payments:write']);
+        $this->postJson("/api/revolut/connections/{$this->connection->id}/pay", $this->payload(5000))->assertStatus(202);
+
+        // A different approver on the same team approves.
+        $checker = User::factory()->create(['current_team_id' => $this->team]);
+        $checker->assignRole('approver');
+
+        $payment = OutboundPayment::first();
+        $step = $payment->approvalRequest()->first()->steps()->first();
+        app(ApprovalService::class)->approve($step, $checker);
+
+        $payment->refresh();
+        $this->assertSame('sent', $payment->status);
+        Http::assertSent(fn ($r) => str_contains($r->url(), '/pay') && $r['request_id'] === $payment->idempotency_key);
+    }
+
+    public function test_maker_cannot_approve_their_own_payment(): void
+    {
+        Http::fake();
+        $this->rule(1000);
+
+        Sanctum::actingAs($this->maker, ['payments:write']);
+        $this->postJson("/api/revolut/connections/{$this->connection->id}/pay", $this->payload(5000))->assertStatus(202);
+
+        $payment = OutboundPayment::first();
+        $step = $payment->approvalRequest()->first()->steps()->first();
+
+        // Maker has the approver role, but maker != checker must block self-approval.
+        $this->expectException(ApprovalDeniedException::class);
+        app(ApprovalService::class)->approve($step, $this->maker->fresh());
+    }
+}

--- a/tests/Feature/Api/PlaidWebhookControllerTest.php
+++ b/tests/Feature/Api/PlaidWebhookControllerTest.php
@@ -9,6 +9,7 @@ use App\Models\BankConnection;
 use App\Models\User;
 use Firebase\JWT\JWT;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Queue;
@@ -54,7 +55,7 @@ class PlaidWebhookControllerTest extends TestCase
             'alg' => 'ES256',
         ];
 
-        \Illuminate\Support\Facades\Cache::flush(); // JWK is cached by kid — isolate across the suite
+        Cache::flush(); // JWK is cached by kid — isolate across the suite
 
         $this->user = User::factory()->create();
         $this->connection = BankConnection::factory()->create([

--- a/tests/Feature/Api/PlaidWebhookControllerTest.php
+++ b/tests/Feature/Api/PlaidWebhookControllerTest.php
@@ -1,12 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Feature\Api;
 
 use App\Jobs\SyncPlaidTransactionsJob;
 use App\Models\BankConnection;
 use App\Models\User;
+use Firebase\JWT\JWT;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Queue;
 use Tests\TestCase;
 
@@ -18,11 +22,39 @@ class PlaidWebhookControllerTest extends TestCase
 
     protected BankConnection $connection;
 
+    private string $privateKeyPem;
+
+    /** @var array<string, mixed> */
+    private array $jwk;
+
+    private const KID = 'test-kid-1';
+
     protected function setUp(): void
     {
         parent::setUp();
 
-        Config::set('services.plaid.webhook_verification_key', 'test_verification_key');
+        Config::set('services.plaid.environment', 'sandbox');
+        Config::set('services.plaid.client_id', 'test_client');
+        Config::set('services.plaid.secret', 'test_secret');
+
+        // Generate a throwaway EC P-256 keypair; expose the public half as the JWK
+        // Plaid's key endpoint would return, and sign webhook JWTs with the private.
+        $res = openssl_pkey_new(['private_key_type' => OPENSSL_KEYTYPE_EC, 'curve_name' => 'prime256v1']);
+        openssl_pkey_export($res, $privatePem);
+        $this->privateKeyPem = $privatePem;
+        $details = openssl_pkey_get_details($res);
+
+        $this->jwk = [
+            'kty' => 'EC',
+            'crv' => 'P-256',
+            'x' => $this->b64url($details['ec']['x']),
+            'y' => $this->b64url($details['ec']['y']),
+            'kid' => self::KID,
+            'use' => 'sig',
+            'alg' => 'ES256',
+        ];
+
+        \Illuminate\Support\Facades\Cache::flush(); // JWK is cached by kid — isolate across the suite
 
         $this->user = User::factory()->create();
         $this->connection = BankConnection::factory()->create([
@@ -32,147 +64,145 @@ class PlaidWebhookControllerTest extends TestCase
         ]);
     }
 
-    public function test_webhook_rejects_invalid_signature(): void
+    private function b64url(string $bin): string
     {
-        $payload = [
-            'webhook_type' => 'TRANSACTIONS',
-            'webhook_code' => 'SYNC_UPDATES_AVAILABLE',
-            'item_id' => 'item_test_123',
-        ];
-
-        $response = $this->postJson('/api/webhooks/plaid', $payload, [
-            'Plaid-Verification' => 'invalid_signature',
-        ]);
-
-        $response->assertStatus(401)
-            ->assertJson([
-                'success' => false,
-                'message' => 'Invalid signature',
-            ]);
+        return rtrim(strtr(base64_encode($bin), '+/', '-_'), '=');
     }
 
-    public function test_webhook_accepts_valid_signature(): void
+    /** Plaid's key endpoint returns our test JWK. */
+    private function fakeKeyOk(): void
+    {
+        Http::fake(['sandbox.plaid.com/webhook_verification_key/get' => Http::response(['key' => $this->jwk], 200)]);
+    }
+
+    /** Sign a Plaid-style webhook JWT binding to $bodyJson. */
+    private function jwtFor(string $bodyJson, array $overrides = [], string $alg = 'ES256', ?string $key = null): string
+    {
+        $claims = array_merge([
+            'iat' => time(),
+            'request_body_sha256' => hash('sha256', $bodyJson),
+        ], $overrides);
+
+        return JWT::encode($claims, $key ?? $this->privateKeyPem, $alg, self::KID);
+    }
+
+    /** POST a payload with a correctly-signed verification JWT. */
+    private function postSigned(array $payload)
+    {
+        $this->fakeKeyOk();
+        $body = json_encode($payload);
+
+        return $this->call('POST', '/api/webhooks/plaid', [], [], [], [
+            'CONTENT_TYPE' => 'application/json',
+            'HTTP_ACCEPT' => 'application/json',
+            'HTTP_PLAID_VERIFICATION' => $this->jwtFor($body),
+        ], $body);
+    }
+
+    public function test_rejects_a_non_jwt_signature(): void
+    {
+        $response = $this->postJson('/api/webhooks/plaid', ['webhook_type' => 'TRANSACTIONS'], [
+            'Plaid-Verification' => 'not-a-jwt',
+        ]);
+
+        $response->assertStatus(401)->assertJson(['success' => false, 'message' => 'Invalid signature']);
+    }
+
+    public function test_accepts_a_valid_signature(): void
     {
         Queue::fake();
 
-        $payload = [
+        $response = $this->postSigned([
             'webhook_type' => 'TRANSACTIONS',
             'webhook_code' => 'SYNC_UPDATES_AVAILABLE',
             'item_id' => $this->connection->plaid_item_id,
-        ];
-
-        $bodyJson = json_encode($payload);
-        $signature = base64_encode(hash_hmac('sha256', $bodyJson, 'test_verification_key', true));
-
-        $response = $this->postJson('/api/webhooks/plaid', $payload, [
-            'Plaid-Verification' => $signature,
         ]);
 
-        $response->assertStatus(200)
-            ->assertJson([
-                'success' => true,
-                'message' => 'Webhook processed',
-            ]);
+        $response->assertStatus(200)->assertJson(['success' => true, 'message' => 'Webhook processed']);
     }
 
-    public function test_webhook_dispatches_sync_job_for_transactions_update(): void
+    public function test_dispatches_sync_job_for_transactions_update(): void
     {
         Queue::fake();
 
-        $payload = [
+        $this->postSigned([
             'webhook_type' => 'TRANSACTIONS',
             'webhook_code' => 'SYNC_UPDATES_AVAILABLE',
             'item_id' => $this->connection->plaid_item_id,
-        ];
-
-        $bodyJson = json_encode($payload);
-        $signature = base64_encode(hash_hmac('sha256', $bodyJson, 'test_verification_key', true));
-
-        $this->postJson('/api/webhooks/plaid', $payload, [
-            'Plaid-Verification' => $signature,
         ]);
 
         Queue::assertPushed(SyncPlaidTransactionsJob::class, fn ($job): bool => $job->connectionId === $this->connection->id);
     }
 
-    public function test_webhook_handles_item_error(): void
+    public function test_handles_item_error(): void
     {
-        $payload = [
+        $this->postSigned([
             'webhook_type' => 'ITEM',
             'webhook_code' => 'ERROR',
             'item_id' => $this->connection->plaid_item_id,
-            'error' => [
-                'error_code' => 'ITEM_LOGIN_REQUIRED',
-                'error_message' => 'User credentials are required',
-            ],
-        ];
-
-        $bodyJson = json_encode($payload);
-        $signature = base64_encode(hash_hmac('sha256', $bodyJson, 'test_verification_key', true));
-
-        $this->postJson('/api/webhooks/plaid', $payload, [
-            'Plaid-Verification' => $signature,
+            'error' => ['error_code' => 'ITEM_LOGIN_REQUIRED', 'error_message' => 'creds required'],
         ]);
 
-        $this->assertDatabaseHas('bank_connections', [
-            'id' => $this->connection->id,
-            'status' => 'requires_reauth',
-        ]);
+        $this->assertDatabaseHas('bank_connections', ['id' => $this->connection->id, 'status' => 'requires_reauth']);
     }
 
-    public function test_webhook_handles_user_permission_revoked(): void
+    public function test_rejects_body_tampering(): void
     {
-        $payload = [
-            'webhook_type' => 'ITEM',
-            'webhook_code' => 'USER_PERMISSION_REVOKED',
-            'item_id' => $this->connection->plaid_item_id,
-        ];
+        // Sign a JWT for one body, then submit a DIFFERENT body: the
+        // request_body_sha256 claim no longer matches -> reject.
+        $this->fakeKeyOk();
+        $signedBody = json_encode(['webhook_type' => 'TRANSACTIONS', 'item_id' => $this->connection->plaid_item_id]);
+        $tamperedBody = json_encode(['webhook_type' => 'TRANSACTIONS', 'item_id' => 'attacker_item']);
 
-        $bodyJson = json_encode($payload);
-        $signature = base64_encode(hash_hmac('sha256', $bodyJson, 'test_verification_key', true));
+        $response = $this->call('POST', '/api/webhooks/plaid', [], [], [], [
+            'CONTENT_TYPE' => 'application/json',
+            'HTTP_ACCEPT' => 'application/json',
+            'HTTP_PLAID_VERIFICATION' => $this->jwtFor($signedBody),
+        ], $tamperedBody);
 
-        $this->postJson('/api/webhooks/plaid', $payload, [
-            'Plaid-Verification' => $signature,
-        ]);
-
-        $this->assertDatabaseHas('bank_connections', [
-            'id' => $this->connection->id,
-            'status' => 'revoked',
-        ]);
+        $response->assertStatus(401);
     }
 
-    public function test_webhook_handles_unknown_item_gracefully(): void
+    public function test_rejects_stale_iat(): void
     {
-        Queue::fake();
+        $this->fakeKeyOk();
+        $body = json_encode(['webhook_type' => 'TRANSACTIONS', 'item_id' => $this->connection->plaid_item_id]);
 
-        $payload = [
-            'webhook_type' => 'TRANSACTIONS',
-            'webhook_code' => 'SYNC_UPDATES_AVAILABLE',
-            'item_id' => 'unknown_item_id',
-        ];
+        $response = $this->call('POST', '/api/webhooks/plaid', [], [], [], [
+            'CONTENT_TYPE' => 'application/json',
+            'HTTP_ACCEPT' => 'application/json',
+            'HTTP_PLAID_VERIFICATION' => $this->jwtFor($body, ['iat' => time() - 600]),
+        ], $body);
 
-        $bodyJson = json_encode($payload);
-        $signature = base64_encode(hash_hmac('sha256', $bodyJson, 'test_verification_key', true));
-
-        $response = $this->postJson('/api/webhooks/plaid', $payload, [
-            'Plaid-Verification' => $signature,
-        ]);
-
-        $response->assertStatus(200);
-        Queue::assertNothingPushed();
+        $response->assertStatus(401);
     }
 
-    public function test_webhook_without_verification_key_configured_rejects(): void
+    public function test_rejects_algorithm_confusion(): void
     {
-        Config::set('services.plaid.webhook_verification_key');
+        // An HS256 token must be rejected at the alg check, never verified.
+        $body = json_encode(['webhook_type' => 'TRANSACTIONS', 'item_id' => $this->connection->plaid_item_id]);
 
-        $payload = [
-            'webhook_type' => 'TRANSACTIONS',
-            'webhook_code' => 'SYNC_UPDATES_AVAILABLE',
-            'item_id' => 'item_test_123',
-        ];
+        $response = $this->call('POST', '/api/webhooks/plaid', [], [], [], [
+            'CONTENT_TYPE' => 'application/json',
+            'HTTP_ACCEPT' => 'application/json',
+            'HTTP_PLAID_VERIFICATION' => $this->jwtFor($body, [], 'HS256', str_repeat('x', 64)),
+        ], $body);
 
-        $response = $this->postJson('/api/webhooks/plaid', $payload);
+        $response->assertStatus(401);
+    }
+
+    public function test_rejects_when_verification_key_unavailable(): void
+    {
+        // Plaid's key endpoint down -> cannot verify -> fail closed.
+        Http::fake(['sandbox.plaid.com/webhook_verification_key/get' => Http::response([], 500)]);
+
+        $body = json_encode(['webhook_type' => 'TRANSACTIONS', 'item_id' => $this->connection->plaid_item_id]);
+
+        $response = $this->call('POST', '/api/webhooks/plaid', [], [], [], [
+            'CONTENT_TYPE' => 'application/json',
+            'HTTP_ACCEPT' => 'application/json',
+            'HTTP_PLAID_VERIFICATION' => $this->jwtFor($body),
+        ], $body);
 
         $response->assertStatus(401);
     }

--- a/tests/Unit/Services/PlaidServiceTest.php
+++ b/tests/Unit/Services/PlaidServiceTest.php
@@ -276,10 +276,11 @@ class PlaidServiceTest extends TestCase
             && $request['options']['account_ids'] === ['acc_123', 'acc_456']);
     }
 
-    public function test_verify_webhook_signature_with_valid_signature(): void
+    public function test_verify_webhook_signature_rejects_legacy_hmac(): void
     {
-        Config::set('services.plaid.webhook_verification_key', 'test_secret_key');
-
+        // The old shared-secret HMAC scheme is no longer accepted — only Plaid's
+        // per-message ES256 JWS is (valid-JWT path covered end-to-end in
+        // PlaidWebhookControllerTest). A legacy HMAC signature must be rejected.
         $bodyJson = '{"webhook_type":"TRANSACTIONS","webhook_code":"SYNC_UPDATES_AVAILABLE"}';
         $signature = base64_encode(hash_hmac('sha256', $bodyJson, 'test_secret_key', true));
 
@@ -287,7 +288,7 @@ class PlaidServiceTest extends TestCase
             'Plaid-Verification' => $signature,
         ]);
 
-        $this->assertTrue($result);
+        $this->assertFalse($result);
     }
 
     public function test_verify_webhook_signature_with_invalid_signature(): void


### PR DESCRIPTION
## Summary

Follow-up to #859 (which merged the first wave of OWASP audit fixes). This PR completes the three items that #859 flagged as deferred/decision-gated. Two commits; **617 tests passing**.

## Fixed

- **Mandatory 2FA by default.** `ACCOUNTING_ENFORCE_2FA` now defaults on. The existing `EnsureTwoFactorEnabled` middleware redirects un-enrolled privileged (`super_admin`/`admin`) users to the enrolment UI — graceful, not a lockout — and stays overridable per deploy.

- **Real Plaid webhook verification.** Replaced the shared-secret HMAC check (wrong scheme — Plaid signs a per-message ES256 JWS) with proper JWT verification: fetch the signing JWK by `kid` from `/webhook_verification_key/get` (cached 24h), verify the ES256 signature via `firebase/php-jwt`, reject non-ES256 algorithms, replay-guard on `iat` (≤5 min), and bind the token to the body via the `request_body_sha256` claim. Fails closed on every branch.

- **Threshold maker-checker for outbound payments.** Each `POST /revolut/.../pay` now creates an `OutboundPayment` routed through the existing `Approvable` flow: below the `ApprovalRule` threshold it auto-approves and the `SendApprovedOutboundPayment` listener fires the Revolut call inline (`idempotency_key` → `request_id`), returning `201`; at/above the threshold it returns `202` and waits for a second approver via the `PendingApprovals` flow. Maker ≠ checker is enforced in `ApprovalService::canAct` (a requester cannot approve their own payment; no-op for approvables without a `requested_by` column).

## Verification
- Full suite: **617 passed**.
- `PlaidWebhookControllerTest` rewritten with a generated EC P-256 keypair fixture: valid signature, body tampering, stale `iat`, algorithm confusion, and key-endpoint-unavailable all covered.
- `OutboundPaymentApprovalTest`: below-threshold immediate send, above-threshold pending (nothing sent), approval-executes-send with `request_id` forwarded, and self-approval denied.

## Caveat
- The Plaid JWT path is fixture-tested but **not verified against live Plaid** — worth a sandbox smoke test before relying on Plaid webhooks in production.
